### PR TITLE
yast2-printer.spec: Remove /bin/ping dependency.

### DIFF
--- a/package/yast2-printer.changes
+++ b/package/yast2-printer.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed May 18 19:01:28 UTC 2016 - mchandras@suse.de
+
+- Remove /bin/ping dependency. All references to 'ping' have been
+  removed in 3.1.2. This allows us to not depend to iputils anymore.
+- 3.1.5
+
+-------------------------------------------------------------------
 Mon Apr  4 09:49:41 CEST 2016 - schubi@suse.de
 
 - Using "uptime" from package yast2 instead of Builtins.time.

--- a/package/yast2-printer.spec
+++ b/package/yast2-printer.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-printer
-Version:        3.1.4
+Version:        3.1.5
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
@@ -33,7 +33,7 @@ BuildRequires:  yast2-testsuite
 
 Recommends:     cups-client iptables netcat samba-client
 
-Requires:       /bin/mktemp /bin/ping /usr/bin/sed
+Requires:       /bin/mktemp /usr/bin/sed
 Requires:       yast2 >= 3.1.183
 
 # Used to exclude libX11, libXau, libxcb, and libxcb-xlib from the requires list


### PR DESCRIPTION
All references to 'ping' have been removed in 0ba65748c88b
("apply jsmeix patches upstream"). This allows us to not
depend to iputils anymore