### PR TITLE
Security Audit Fixes: Hardening for Calling External Commands

### DIFF
--- a/package/yast2-printer.changes
+++ b/package/yast2-printer.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Mar 21 19:25:40 UTC 2019 - Stefan Hundhammer <shundhammer@suse.com>
+
+- Security hardening (bsc#1118291)
+- 4.1.1
+
+-------------------------------------------------------------------
 Tue Feb 26 11:32:39 UTC 2019 - José Iván López González <jlopez@suse.com>
 
 - Version bump (bsc#1124009)

--- a/package/yast2-printer.spec
+++ b/package/yast2-printer.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-printer
-Version:        4.1.0
+Version:        4.1.1
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/clients/printer.rb
+++ b/src/clients/printer.rb
@@ -24,9 +24,8 @@
 # Summary:	Main file
 # Authors:	Johannes Meixner <jsmeix@suse.de>
 #
-# $Id: printer.ycp 27914 2006-02-13 14:32:08Z locilka $
-#
 # Main file for printer configuration. Uses all other files.
+
 module Yast
   class PrinterClient < Client
     def main

--- a/src/clients/printer_auto.rb
+++ b/src/clients/printer_auto.rb
@@ -25,8 +25,6 @@
 # Authors:	Michal Zugec <mzugec@suse.cz>
 #              Johannes Meixner <jsmeix@suse.de>
 #
-# $Id: printer_auto.ycp 27914 2006-02-13 14:32:08Z locilka $
-#
 # This is a client for autoinstallation. It takes its arguments,
 # goes through the configuration and return the setting.
 # Does not do any changes to the configuration.

--- a/src/clients/printer_auto.rb
+++ b/src/clients/printer_auto.rb
@@ -49,6 +49,9 @@
 # @return [Hash] edited settings, Summary or boolean on success depending on called function
 # @example map mm = $[ "FAIL_DELAY" : "77" ];
 # @example map ret = WFM::CallFunction ("printer_auto", [ "Summary", mm ]);
+
+require "shellwords"
+
 module Yast
   class PrinterAutoClient < Client
     def main

--- a/src/clients/printer_auto.rb
+++ b/src/clients/printer_auto.rb
@@ -276,7 +276,7 @@ module Yast
       Builtins.y2milestone("Printer auto finished")
       Builtins.y2milestone("----------------------------------------")
 
-      deep_copy(@ret) 
+      deep_copy(@ret)
 
       # EOF
     end
@@ -354,7 +354,7 @@ module Yast
       # Intentionally not escaping file_name in the "grep" call:
       # If there are weird characters in file_name, we might simply make one backup
       # of it too many which won't hurt.
-      if Printerlib.ExecuteBashCommand("rpm -V -f " + file_name.shellescape + " | grep -q '^..5.*" + file_name + "$'")
+      if Printerlib.ExecuteBashCommand("rpm -V -f " + file_name.shellescape + " | grep -q '^..5.*'" + file_name.shellescape + "'$'")
         if Printerlib.ExecuteBashCommand("cp -p " + file_name.shellescape + " " + file_name.shellescape + ".yast2save")
           return true
         end

--- a/src/clients/printer_proposal.rb
+++ b/src/clients/printer_proposal.rb
@@ -24,10 +24,9 @@
 # Summary:	Proposal function dispatcher.
 # Authors:	Johannes Meixner <jsmeix@suse.de>
 #
-# $Id: printer_proposal.ycp 27914 2006-02-13 14:32:08Z locilka $
-#
 # Proposal function dispatcher for printer configuration.
 # See source/installation/proposal/proposal-API.txt
+
 module Yast
   class PrinterProposalClient < Client
     def main

--- a/src/include/printer/autoconfig.rb
+++ b/src/include/printer/autoconfig.rb
@@ -23,8 +23,7 @@
 # Package:     Configuration of printer
 # Summary:     Automatic Configuration dialog definition
 # Authors:     Johannes Meixner <jsmeix@suse.de>
-#
-# $Id: autoconfig.ycp 27914 2006-02-13 14:32:08Z locilka $
+
 module Yast
   module PrinterAutoconfigInclude
     def initialize_printer_autoconfig(include_target)

--- a/src/include/printer/autoconfig.rb
+++ b/src/include/printer/autoconfig.rb
@@ -107,9 +107,7 @@ module Yast
             Printerlib.client_conf_server_name
           )
         else
-          if !Printerlib.ExecuteBashCommand(
-              Ops.add(Printerlib.yast_bin_dir, "cups_client_only none")
-            )
+          if !Printerlib.ExecuteBashCommand(Printerlib.yast_bin_dir + "cups_client_only none")
             Popup.ErrorDetails(
               _(
                 "Failed to remove the 'ServerName' entry in /etc/cups/client.conf"

--- a/src/include/printer/basicadd.rb
+++ b/src/include/printer/basicadd.rb
@@ -23,8 +23,7 @@
 # Package:     Configuration of printer
 # Summary:     Basic add dialog definition
 # Authors:     Johannes Meixner <jsmeix@suse.de>
-#
-# $Id: basicadd.ycp 27914 2006-02-13 14:32:08Z locilka $
+
 module Yast
   module PrinterBasicaddInclude
     def initialize_printer_basicadd(include_target)

--- a/src/include/printer/basicmodify.rb
+++ b/src/include/printer/basicmodify.rb
@@ -24,6 +24,8 @@
 # Summary:     Basic modify dialog definition
 # Authors:     Johannes Meixner <jsmeix@suse.de>
 
+require "shellwords"
+
 module Yast
   module PrinterBasicmodifyInclude
     def initialize_printer_basicmodify(include_target)

--- a/src/include/printer/basicmodify.rb
+++ b/src/include/printer/basicmodify.rb
@@ -23,8 +23,7 @@
 # Package:     Configuration of printer
 # Summary:     Basic modify dialog definition
 # Authors:     Johannes Meixner <jsmeix@suse.de>
-#
-# $Id: basicmodify.ycp 27914 2006-02-13 14:32:08Z locilka $
+
 module Yast
   module PrinterBasicmodifyInclude
     def initialize_printer_basicmodify(include_target)

--- a/src/include/printer/basicmodify.rb
+++ b/src/include/printer/basicmodify.rb
@@ -138,8 +138,7 @@ module Yast
       # The leading part "/etc/" may vary depending on how the local cupsd
       # is installed or configured, see "/usr/bin/cups-config --serverroot".
       if "" != ppd
-        commandline = "test -r " + ppd.shellescape
-        if Printerlib.ExecuteBashCommand(commandline)
+        if Printerlib.ExecuteBashCommand("test -r " + ppd.shellescape)
           driver_options_content = PushButton(
             Id(:driver_options),
             # Label of a PushButton to go to a dialog
@@ -155,7 +154,9 @@ module Yast
         # which suppresses it in certain "lpinfo -m" output.
         # Note the YCP quoting: \" becomes " and \\n becomes \n in the commandline.
         commandline = "grep '^*NickName' " + ppd.shellescape
-        commandline += " | cut -s -d '\"' -f2 | sed -e 's/(recommended)//' -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//' | tr -s ' ' | tr -d '\\n'"
+        commandline += " | cut -s -d '\"' -f2"
+        commandline += " | sed -e 's/(recommended)//' -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//'"
+        commandline += " | tr -s ' ' | tr -d '\\n'"
         if Printerlib.ExecuteBashCommand(commandline)
           Builtins.y2milestone(
             "'%1' stdout (nick_name) is: '%2'",
@@ -207,7 +208,7 @@ module Yast
                   end
                 end
               end
-            end 
+            end
 
             Builtins.y2milestone(
               "Default paper size is: '%1'",

--- a/src/include/printer/basicmodify.rb
+++ b/src/include/printer/basicmodify.rb
@@ -138,7 +138,7 @@ module Yast
       # The leading part "/etc/" may vary depending on how the local cupsd
       # is installed or configured, see "/usr/bin/cups-config --serverroot".
       if "" != ppd
-        commandline = Ops.add("test -r ", ppd)
+        commandline = "test -r " + ppd.shellescape
         if Printerlib.ExecuteBashCommand(commandline)
           driver_options_content = PushButton(
             Id(:driver_options),
@@ -154,10 +154,8 @@ module Yast
       if Builtins.issubstring(ppd, "/cups/ppd/")
         # which suppresses it in certain "lpinfo -m" output.
         # Note the YCP quoting: \" becomes " and \\n becomes \n in the commandline.
-        commandline = Ops.add(
-          Ops.add("grep '^*NickName' ", ppd),
-          " | cut -s -d '\"' -f2 | sed -e 's/(recommended)//' -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//' | tr -s ' ' | tr -d '\\n'"
-        )
+        commandline = "grep '^*NickName' " + ppd.shellescape
+        commandline += " | cut -s -d '\"' -f2 | sed -e 's/(recommended)//' -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//' | tr -s ' ' | tr -d '\\n'"
         if Printerlib.ExecuteBashCommand(commandline)
           Builtins.y2milestone(
             "'%1' stdout (nick_name) is: '%2'",
@@ -572,10 +570,7 @@ module Yast
           break
         end
         if :next == user_input
-          commandline = Ops.add(
-            Ops.add("/usr/sbin/lpadmin -h localhost -p '", name),
-            "'"
-          )
+          commandline = "/usr/sbin/lpadmin -h localhost -p " + name.shellescape
           something_has_changed = false
           set_paper_size_later = false
           selected_connection_index = Convert.to_integer(
@@ -588,10 +583,7 @@ module Yast
               ""
             )
             if "" != uri
-              commandline = Ops.add(
-                Ops.add(Ops.add(commandline, " -v '"), uri),
-                "'"
-              )
+              commandline += " -v " + uri.shellescape
               Printer.current_device_uri = uri
               something_has_changed = true
             end
@@ -602,10 +594,7 @@ module Yast
           if Ops.greater_or_equal(selected_ppd_index, 0)
             ppd = Ops.get(Printer.ppds, [selected_ppd_index, "ppd"], "")
             if "" != ppd
-              commandline = Ops.add(
-                Ops.add(Ops.add(commandline, " -m '"), ppd),
-                "'"
-              )
+              commandline += " -m " + ppd.shellescape
               something_has_changed = true
               # The paper size for a new driver will be only set
               # after the new driver was actually successfully set:
@@ -620,11 +609,11 @@ module Yast
                 :CurrentButton
               )
               if :a4 == paper_size && "A4" != default_paper_size
-                commandline = Ops.add(commandline, " -o PageSize=A4")
+                commandline += " -o PageSize=A4"
                 something_has_changed = true
               end
               if :letter == paper_size && "Letter" != default_paper_size
-                commandline = Ops.add(commandline, " -o PageSize=Letter")
+                commandline += " -o PageSize=Letter"
                 something_has_changed = true
               end
             end
@@ -642,10 +631,7 @@ module Yast
             " "
           )
           if description_input != description
-            commandline = Ops.add(
-              Ops.add(Ops.add(commandline, " -D '"), description_input),
-              "'"
-            )
+            commandline += " -D " + description_input.shellescape
             something_has_changed = true
           end
           location_input = Convert.to_string(
@@ -661,10 +647,7 @@ module Yast
             " "
           )
           if location_input != location
-            commandline = Ops.add(
-              Ops.add(Ops.add(commandline, " -L '"), location_input),
-              "'"
-            )
+            commandline += " -L " + location_input.shellescape
             something_has_changed = true
           end
           is_default_input = Convert.to_boolean(
@@ -674,13 +657,7 @@ module Yast
             something_has_changed = true
             if is_default_input
               # with other option settings so that a separate lpadmin command is called:
-              commandline = Ops.add(
-                Ops.add(
-                  Ops.add(commandline, " ; /usr/sbin/lpadmin -h localhost -d '"),
-                  name
-                ),
-                "'"
-              )
+              commandline += " ; /usr/sbin/lpadmin -h localhost -d " + name.shellescape
             else
               # see http://www.cups.org/newsgroups.php?gcups.general+v:31874
               # All one can do is set up a dummy queue, make it the default, and remove it.
@@ -688,16 +665,9 @@ module Yast
               # nor is printing enabled (no '-E' as last lpadmin option)
               # nor is it announced ("shared") to whatever BrowseAddress in cupsd.conf.
               # Here I assume blindly that no queue "yast2unsetdefaultqueue" exists.
-              commandline = Ops.add(
-                Ops.add(
-                  Ops.add(
-                    commandline,
-                    " ; /usr/sbin/lpadmin -h localhost -p yast2unsetdefaultqueue -v file:/dev/null -o printer-is-shared=false"
-                  ),
-                  " ; /usr/sbin/lpadmin -h localhost -d yast2unsetdefaultqueue"
-                ),
-                " ; /usr/sbin/lpadmin -h localhost -x yast2unsetdefaultqueue"
-              )
+              commandline += " ; /usr/sbin/lpadmin -h localhost -p yast2unsetdefaultqueue -v file:/dev/null -o printer-is-shared=false"
+              commandline += " ; /usr/sbin/lpadmin -h localhost -d yast2unsetdefaultqueue"
+              commandline += " ; /usr/sbin/lpadmin -h localhost -x yast2unsetdefaultqueue"
             end
           end
           accepting_jobs_input = Convert.to_boolean(
@@ -706,21 +676,9 @@ module Yast
           if accepting_jobs_input != accepting_jobs
             something_has_changed = true
             if accepting_jobs_input
-              commandline = Ops.add(
-                Ops.add(
-                  Ops.add(commandline, " ; /usr/sbin/accept -h localhost '"),
-                  name
-                ),
-                "'"
-              )
+              commandline += " ; /usr/sbin/accept -h localhost " + name.shellescape
             else
-              commandline = Ops.add(
-                Ops.add(
-                  Ops.add(commandline, " ; /usr/sbin/reject -h localhost '"),
-                  name
-                ),
-                "'"
-              )
+              commandline += " ; /usr/sbin/reject -h localhost " + name.shellescape
             end
           end
           printing_enabled_input = Convert.to_boolean(
@@ -729,24 +687,9 @@ module Yast
           if printing_enabled_input != printing_enabled
             something_has_changed = true
             if printing_enabled_input
-              commandline = Ops.add(
-                Ops.add(
-                  Ops.add(commandline, " ; /usr/sbin/cupsenable -h localhost '"),
-                  name
-                ),
-                "'"
-              )
+              commandline += " ; /usr/sbin/cupsenable -h localhost " + name.shellescape
             else
-              commandline = Ops.add(
-                Ops.add(
-                  Ops.add(
-                    commandline,
-                    " ; /usr/sbin/cupsdisable -h localhost '"
-                  ),
-                  name
-                ),
-                "'"
-              )
+              commandline += " ; /usr/sbin/cupsdisable -h localhost " + name.shellescape
             end
           end
           if something_has_changed
@@ -783,27 +726,13 @@ module Yast
                   # and http://www.cups.org/str.php?L2848
                   if "" != default_paper_size
                     # Note the YCP quoting: \\< becomes \< and \\> becomes \> in the commandline.
-                    commandline = Ops.add(
-                      Ops.add(
-                        Ops.add(
-                          Ops.add("lpoptions -h localhost -p '", name),
-                          "' -l | grep '^PageSize.*\\<"
-                        ),
-                        default_paper_size
-                      ),
-                      "\\>'"
-                    )
+                    # Note that default_paper_size does not need to be escaped because it is only set to
+                    # well-defined values "A4" or "Letter" if paper_size is one of those two.
+                    commandline = "lpoptions -h localhost -p " + name.shellescape + " -l"
+                    commandline += " | grep '^PageSize.*\\<" + default_paper_size + "\\>'"
                     if Printerlib.ExecuteBashCommand(commandline)
-                      commandline = Ops.add(
-                        Ops.add(
-                          Ops.add(
-                            Ops.add("/usr/sbin/lpadmin -h localhost -p '", name),
-                            "' -o 'PageSize="
-                          ),
-                          default_paper_size
-                        ),
-                        "'"
-                      )
+                      commandline = "/usr/sbin/lpadmin -h localhost -p " + name.shellescape
+                      commandline += " -o PageSize=" + default_paper_size
                       # Do not care if it fails to set the default_paper_size (i.e. show no error message to the user)
                       # because the default_paper_size setting is nice to have but not mandatoty for a working queue:
                       Printerlib.ExecuteBashCommand(commandline)

--- a/src/include/printer/connectionwizard.rb
+++ b/src/include/printer/connectionwizard.rb
@@ -298,12 +298,16 @@ module Yast
           "."
         )
         # Let the whole pipe fail if any of its commands fail (requires bash):
-        grepcommand = "set -o pipefail ; egrep '^DeviceURI " + scheme + "://[^:]+:[^@]+@'" + part1.shellescape + "/" + part2.shellescape
+        grepcommand = "set -o pipefail"
+        grepcommand += " ; egrep '^DeviceURI '" + scheme.shellescape
         if "lpd" == scheme
           # to describe who requested a print job in the form lpd://username@ip-address-or-hostname/...
           # (i.e. grep only for "username@" instead of the usual "username:password@"):
-          grepcommand = "set -o pipefail ; egrep '^DeviceURI " + scheme + "://[^@]+@'" + part1.shellescape + "/" + part2.shellescape
+          grepcommand += "'://[^@]+@'"
+        else
+          grepcommand += "'://[^:]+:[^@]+@'"
         end
+        grepcommand += part1.shellescape + "/" + part2.shellescape
         if "" != Ops.get(parts, 3, "")
           part3 = Builtins.mergestring(
             Builtins.splitstring(Ops.get(parts, 3, ""), special_chars),

--- a/src/include/printer/connectionwizard.rb
+++ b/src/include/printer/connectionwizard.rb
@@ -117,7 +117,7 @@ module Yast
           Builtins.splitstring(output, character),
           encoding
         )
-      end 
+      end
 
       Builtins.y2milestone(
         "URIpercentEncoding from '%1' to '%2'",
@@ -163,7 +163,7 @@ module Yast
         if position != nil && position_lowercase != nil &&
             Ops.less_than(position_lowercase, position) ||
             position == nil && position_lowercase != nil
-          position = position_lowercase 
+          position = position_lowercase
           # For character = ":" and actual percent encoding = "%3a"
           #   position = 5
         end
@@ -218,7 +218,7 @@ module Yast
               Ops.less_than(position_lowercase, position) ||
               position == nil && position_lowercase != nil
             position = position_lowercase
-          end 
+          end
           # For character = "%" and encoding = "%25"
           #   position = nil
           # For character = ":" and encoding = "%3A"
@@ -232,7 +232,7 @@ module Yast
         #   output = "First%3aSecond%3AThird%25Rest"
         # For character = ":" and encoding = "%3A"
         #   output = "First:Second:Third%25Rest"
-      end 
+      end
 
       # output = "First:Second:Third%25Rest"
       Builtins.y2milestone(
@@ -473,7 +473,7 @@ module Yast
             connection_items = Builtins.add(connection_items, connection_item)
           end
         end
-      end 
+      end
 
       if backend ==
           Builtins.substring(current_device_uri, 0, Builtins.size(backend))
@@ -669,7 +669,7 @@ module Yast
                 Item(Id(device_node), device_node)
               )
             end
-          end 
+          end
 
           if !@current_serial_device_node_found
             if "" == @current_serial_device_node
@@ -742,7 +742,7 @@ module Yast
                       Item(Id(item_value), item_value)
                     )
                   end
-                end 
+                end
 
                 if !value_found
                   if "" == value
@@ -787,7 +787,7 @@ module Yast
                       Item(Id(item_value), item_value)
                     )
                   end
-                end 
+                end
 
                 if !value_found
                   if "" == value
@@ -832,7 +832,7 @@ module Yast
                       Item(Id(item_value), item_value)
                     )
                   end
-                end 
+                end
 
                 if !value_found
                   if "" == value
@@ -881,7 +881,7 @@ module Yast
                       Item(Id(item_value), item_text)
                     )
                   end
-                end 
+                end
 
                 if !value_found
                   if "" == value
@@ -926,7 +926,7 @@ module Yast
                       Item(Id(item_value), item_value)
                     )
                   end
-                end 
+                end
 
                 if !value_found
                   if "" == value
@@ -1089,7 +1089,11 @@ module Yast
             # ( hcitool scan | grep '...' ) & sleep 10 ; kill -9 $!
             # would kill only the sub shell.
             if !Printerlib.ExecuteBashCommand(
-                "hcitool scan >/tmp/hcitool_scan.out & sleep 10 ; kill -9 $! ; grep '..:..:..:..:..:..' /tmp/hcitool_scan.out | tr -s ' ' ; rm -f /tmp/hcitool_scan.out"
+                 "hcitool scan >/tmp/hcitool_scan.out & sleep 10" +
+                 " ; kill -9 $!" +
+                 " ; grep '..:..:..:..:..:..' /tmp/hcitool_scan.out" +
+                 " | tr -s ' '" +
+                 " ; rm -f /tmp/hcitool_scan.out"
               )
               Popup.ErrorDetails(
                 _("Failed to get a list of bluetooth device IDs."),
@@ -1156,7 +1160,7 @@ module Yast
                   end
                 end
               end
-            end 
+            end
 
             if !current_bluetooth_device_id_found
               if "" == current_bluetooth_device_id
@@ -1466,10 +1470,15 @@ module Yast
             end
             # Be backward compatible for openSUSE < 11.3 and be prepared for /usr/lib64/cups/
             Printerlib.ExecuteBashCommand(
-              "ls -1 /usr/lib*/cups/backend/smb | head -n1 | tr -d '[:space:]'"
+              "ls -1 /usr/lib*/cups/backend/smb" +
+              " | head -n1 | tr -d '[:space:]'"
             )
             # readlink is in the coreutils RPM so that it is available in any case.
-            Printerlib.ExecuteBashCommand("readlink " + Ops.get_string(Printerlib.result, "stdout", "") + " | tr -d '[:space:]'")
+            Printerlib.ExecuteBashCommand(
+              "readlink " +
+              Ops.get_string(Printerlib.result, "stdout", "") +
+              " | tr -d '[:space:]'"
+            )
             # Only if /usr/lib[64]/cups/backend/smb -> /usr/bin/get_printing_ticket
             # there is support for Active Directory (R):
             if "/usr/bin/get_printing_ticket" ==
@@ -2926,13 +2935,8 @@ module Yast
           when :tcp
             host = Convert.to_string(UI.QueryWidget(:hostname, :Value))
             port = Convert.to_string(UI.QueryWidget(:port_or_queue, :Value))
-            test_command = Builtins.sformat(
-              "%1test_remote_socket \"%2\" \"%3\" %4",
-              Printerlib.yast_bin_dir,
-              host,
-              port,
-              timeout
-            )
+            test_command = Printerlib.yast_bin_dir + "test_remote_socket"
+            test_command += " #{host.shellescape} #{port.shellescape} #{timeout.shellescape}"
             if !Printerlib.ExecuteBashCommand(test_command)
               Popup.ErrorDetails(
                 Builtins.sformat(
@@ -2953,13 +2957,8 @@ module Yast
             host = Convert.to_string(UI.QueryWidget(:hostname, :Value))
             queue = Convert.to_string(UI.QueryWidget(:port_or_queue, :Value))
             port = "515"
-            test_command = Builtins.sformat(
-              "%1test_remote_lpd \"%2\" \"%3\" %4",
-              Printerlib.yast_bin_dir,
-              host,
-              queue,
-              timeout
-            )
+            test_command = Printerlib.yast_bin_dir + "test_remote_lpd"
+            test_command += " #{host.shellescape} #{queue.shellescape} #{timeout.shellescape}"
             if !Printerlib.ExecuteBashCommand(test_command)
               Popup.ErrorDetails(
                 Builtins.sformat(
@@ -2979,13 +2978,8 @@ module Yast
           when :cups
             host = Convert.to_string(UI.QueryWidget(:hostname, :Value))
             queue = Convert.to_string(UI.QueryWidget(:queue, :Value))
-            test_command = Builtins.sformat(
-              "%1test_remote_ipp \"%2\" \"%3\" %4",
-              Printerlib.yast_bin_dir,
-              host,
-              queue,
-              timeout
-            )
+            test_command = Printerlib.yast_bin_dir + "test_remote_ipp"
+            test_command += " #{host.shellescape} #{queue.shellescape} #{timeout.shellescape}"
             if !Printerlib.ExecuteBashCommand(test_command)
               Popup.ErrorDetails(
                 Builtins.sformat(
@@ -3024,16 +3018,11 @@ module Yast
             workgroup = Convert.to_string(UI.QueryWidget(:domain, :Value))
             user = Convert.to_string(UI.QueryWidget(:user, :Value))
             password = Convert.to_string(UI.QueryWidget(:pass, :Value))
-            test_command = Builtins.sformat(
-              "%1test_remote_smb \"%2\" \"%3\" \"%4\" \"%5\" \"%6\" %7",
-              Printerlib.yast_bin_dir,
-              workgroup,
-              host,
-              queue,
-              user,
-              password,
-              timeout
-            )
+            test_command = Printerlib.yast_bin_dir + "test_remote_smb"
+            test_command += " #{workgroup.shellescape}"
+            test_command += " #{host.shellescape} #{queue.shellescape}"
+            test_command += " #{user.shellescape} #{password.shellescape}"
+            test_command += " #{timeout.shellescape}"
             if !Printerlib.ExecuteBashCommand(test_command)
               if @active_directory
                 Popup.ErrorDetails(
@@ -3076,15 +3065,12 @@ module Yast
             queue = Convert.to_string(UI.QueryWidget(:queue, :Value))
             user = Convert.to_string(UI.QueryWidget(:user, :Value))
             password = Convert.to_string(UI.QueryWidget(:pass, :Value))
-            test_command = Builtins.sformat(
-              "%1test_remote_novell \"%2\" \"%3\" \"%4\" \"%5\" %6",
-              Printerlib.yast_bin_dir,
-              host,
-              queue,
-              user,
-              password,
-              timeout
-            )
+
+            test_command = Printerlib.yast_bin_dir + "test_remote_novell"
+            test_command += " #{host.shellescape} #{queue.shellescape}"
+            test_command += " #{user.shellescape} #{password.shellescape}"
+            test_command += " #{timeout.shellescape}"
+
             if !Printerlib.ExecuteBashCommand(test_command)
               Popup.ErrorDetails(
                 Builtins.sformat(
@@ -3304,7 +3290,7 @@ module Yast
         end
       end
       # ret == `back || ret == `next
-      deep_copy(ret) 
+      deep_copy(ret)
       #UI::CloseDialog();
     end
   end

--- a/src/include/printer/connectionwizard.rb
+++ b/src/include/printer/connectionwizard.rb
@@ -297,20 +297,20 @@ module Yast
           "."
         )
         # Let the whole pipe fail if any of its commands fail (requires bash):
-        grepcommand = "set -o pipefail ; egrep '^DeviceURI " + scheme + "://[^:]+:[^@]+@" + part1 + "/" + part2
+        grepcommand = "set -o pipefail ; egrep '^DeviceURI " + scheme + "://[^:]+:[^@]+@'" + part1.shellescape + "/" + part2.shellescape
         if "lpd" == scheme
           # to describe who requested a print job in the form lpd://username@ip-address-or-hostname/...
           # (i.e. grep only for "username@" instead of the usual "username:password@"):
-          grepcommand = "set -o pipefail ; egrep '^DeviceURI " + scheme + "://[^@]+@" + part1 + "/" + part2
+          grepcommand = "set -o pipefail ; egrep '^DeviceURI " + scheme + "://[^@]+@'" + part1.shellescape + "/" + part2.shellescape
         end
         if "" != Ops.get(parts, 3, "")
           part3 = Builtins.mergestring(
             Builtins.splitstring(Ops.get(parts, 3, ""), special_chars),
             "."
           )
-          grepcommand += "/" + part3
+          grepcommand += "/" + part3.shellescape
         end
-        grepcommand += "$' /etc/cups/printers.conf"
+        grepcommand += "'$' /etc/cups/printers.conf"
         grepcommand += " | sort -u | wc -l | tr -d '[:space:]'"
         Printerlib.ExecuteBashCommand(grepcommand)
         if "1" == Ops.get_string(Printerlib.result, "stdout", "")

--- a/src/include/printer/connectionwizard.rb
+++ b/src/include/printer/connectionwizard.rb
@@ -25,6 +25,8 @@
 # Authors:     Michal Zugec <mzugec@suse.de>
 #              Johannes Meixner <jsmeix@suse.de>
 
+require "shellwords"
+
 module Yast
   module PrinterConnectionwizardInclude
     def initialize_printer_connectionwizard(include_target)

--- a/src/include/printer/connectionwizard.rb
+++ b/src/include/printer/connectionwizard.rb
@@ -24,8 +24,7 @@
 # Summary:     Connection Wizard
 # Authors:     Michal Zugec <mzugec@suse.de>
 #              Johannes Meixner <jsmeix@suse.de>
-#
-# $Id: connectionwizard.ycp 27914 2006-02-13 14:32:08Z locilka $
+
 module Yast
   module PrinterConnectionwizardInclude
     def initialize_printer_connectionwizard(include_target)

--- a/src/include/printer/dialogs.rb
+++ b/src/include/printer/dialogs.rb
@@ -23,8 +23,7 @@
 # Package:     Configuration of printer
 # Summary:     DialogTree definition
 # Authors:     Michal Zugec <mzugec@suse.de>
-#
-# $Id: dialogs.ycp 27914 2006-02-13 14:32:08Z locilka $
+
 module Yast
   module PrinterDialogsInclude
     def initialize_printer_dialogs(include_target)

--- a/src/include/printer/driveradd.rb
+++ b/src/include/printer/driveradd.rb
@@ -23,8 +23,7 @@
 # Package:     Configuration of printer
 # Summary:     Add Driver dialog definition
 # Authors:     Johannes Meixner <jsmeix@suse.de>
-#
-# $Id: driveradd.ycp 27914 2006-02-13 14:32:08Z locilka $
+
 module Yast
   module PrinterDriveraddInclude
     def initialize_printer_driveradd(include_target)

--- a/src/include/printer/driveradd.rb
+++ b/src/include/printer/driveradd.rb
@@ -658,9 +658,7 @@ module Yast
           # Ignore an effectively empty ppd_path_input_value:
           if "" !=
               Builtins.filterchars(ppd_path_input_value, Printer.alnum_chars)
-            if !Printerlib.ExecuteBashCommand(
-                Ops.add(Ops.add("ls -l '", ppd_path_input_value), "'")
-              )
+            if !Printerlib.ExecuteBashCommand("ls -l " + ppd_path_input_value.shellescape)
               Popup.ErrorDetails(
                 Builtins.sformat(
                   # where %1 will be replaced by the file name:
@@ -674,13 +672,7 @@ module Yast
               break
             end
             if !Printerlib.ExecuteBashCommand(
-                Ops.add(
-                  Ops.add(
-                    "cupstestppd -W constraints -W defaults -W translations -r '",
-                    ppd_path_input_value
-                  ),
-                  "'"
-                )
+                 "cupstestppd -W constraints -W defaults -W translations -r " + ppd_path_input_value.shellescape
               )
               Popup.ErrorDetails(
                 _(
@@ -711,14 +703,9 @@ module Yast
               end
             end
             if !Printerlib.ExecuteBashCommand(
-                Ops.add(
-                  Ops.add(
-                    "test -d /usr/share/cups/model/downloaded || mkdir /usr/share/cups/model/downloaded ; cp '",
-                    ppd_path_input_value
-                  ),
-                  "' /usr/share/cups/model/downloaded"
-                )
-              )
+                 "test -d /usr/share/cups/model/downloaded || mkdir /usr/share/cups/model/downloaded" +
+                 " ; cp " + ppd_path_input_value.shellescape + " /usr/share/cups/model/downloaded"
+               )
               Popup.ErrorDetails(
                 _("Failed to make the printer description file available"),
                 Ops.get_string(Printerlib.result, "stderr", "")

--- a/src/include/printer/driveradd.rb
+++ b/src/include/printer/driveradd.rb
@@ -24,6 +24,8 @@
 # Summary:     Add Driver dialog definition
 # Authors:     Johannes Meixner <jsmeix@suse.de>
 
+require "shellwords"
+
 module Yast
   module PrinterDriveraddInclude
     def initialize_printer_driveradd(include_target)

--- a/src/include/printer/driveroptions.rb
+++ b/src/include/printer/driveroptions.rb
@@ -24,6 +24,8 @@
 # Summary:     Driver options dialog definition
 # Authors:     Johannes Meixner <jsmeix@suse.de>
 
+require "shellwords"
+
 module Yast
   module PrinterDriveroptionsInclude
     def initialize_printer_driveroptions(include_target)

--- a/src/include/printer/driveroptions.rb
+++ b/src/include/printer/driveroptions.rb
@@ -23,8 +23,7 @@
 # Package:     Configuration of printer
 # Summary:     Driver options dialog definition
 # Authors:     Johannes Meixner <jsmeix@suse.de>
-#
-# $Id: driveroptions.ycp 27914 2006-02-13 14:32:08Z locilka $
+
 module Yast
   module PrinterDriveroptionsInclude
     def initialize_printer_driveroptions(include_target)

--- a/src/include/printer/driveroptions.rb
+++ b/src/include/printer/driveroptions.rb
@@ -97,10 +97,7 @@ module Yast
         break if ret == :abort || ret == :cancel || ret == :back
         if ret == :next
           Builtins.y2milestone("Driver options: %1", Printer.driver_options)
-          commandline = Ops.add(
-            Ops.add("/usr/sbin/lpadmin -h localhost -p '", name),
-            "'"
-          )
+          commandline = "/usr/sbin/lpadmin -h localhost -p " + name.shellescape
           something_has_changed = false
           Builtins.foreach(Printer.driver_options) do |driver_option|
             keyword = Ops.get_string(driver_option, "keyword", "")
@@ -109,23 +106,14 @@ module Yast
               really_changed = true
               Builtins.foreach(Ops.get_list(driver_option, "values", [])) do |value|
                 really_changed = false if value == Ops.add("*", selected_value)
-              end 
+              end
 
               if really_changed
-                commandline = Ops.add(
-                  Ops.add(
-                    Ops.add(
-                      Ops.add(Ops.add(commandline, " -o '"), keyword),
-                      "="
-                    ),
-                    selected_value
-                  ),
-                  "'"
-                )
+                commandline += " -o " + keyword.shellescape + "=" + selected_value.shellescape
                 something_has_changed = true
               end
             end
-          end 
+          end
 
           if something_has_changed
             Wizard.DisableBackButton

--- a/src/include/printer/helps.rb
+++ b/src/include/printer/helps.rb
@@ -23,8 +23,7 @@
 # Package:     Configuration of printer
 # Summary:     Help texts of all the dialogs
 # Authors:     Johannes Meixner <jsmeix@suse.de>
-#
-# $Id: helps.ycp 27914 2006-02-13 14:32:08Z locilka $
+
 module Yast
   module PrinterHelpsInclude
     def initialize_printer_helps(include_target)

--- a/src/include/printer/overview.rb
+++ b/src/include/printer/overview.rb
@@ -946,7 +946,6 @@ module Yast
               " | sed -e 's/.*-//' | tr -d -c '[:digit:]'"
               # sed is greedy and cuts all up to the last '-' for example
               )
-            )
             test_print_job_number = Ops.get_string(
               Printerlib.result,
               "stdout",

--- a/src/include/printer/overview.rb
+++ b/src/include/printer/overview.rb
@@ -212,9 +212,7 @@ module Yast
                 Printerlib.client_conf_server_name
               )
             )
-            if !Printerlib.ExecuteBashCommand(
-                Ops.add(Printerlib.yast_bin_dir, "cups_client_only none")
-              )
+            if !Printerlib.ExecuteBashCommand(Printerlib.yast_bin_dir + "cups_client_only none")
               Popup.ErrorDetails(
                 _(
                   "Failed to remove the 'ServerName' entry in /etc/cups/client.conf"
@@ -716,31 +714,17 @@ module Yast
           # When this command fails for whatever reason, it is a safe fallback
           # to assume that there are no pending jobs in the queue:
           if Printerlib.ExecuteBashCommand(
-              Ops.add(
-                Ops.add(
-                  Ops.add(
-                    Ops.add("/usr/bin/lpstat -h localhost -o '", queue_name),
-                    "' | egrep -q '^"
-                  ),
-                  queue_name
-                ),
-                "-[0-9]+'"
-              )
+               "/usr/bin/lpstat -h localhost" +
+               " -o " + queue_name.shellescape +
+               " | egrep -q '^'" + queue_name.shellescape + "'-[0-9]+'"
             )
             pending_job_info = _(
               "There are pending print jobs which might be deleted before the testpage is printed."
             )
             if Printerlib.ExecuteBashCommand(
-                Ops.add(
-                  Ops.add(
-                    Ops.add(
-                      Ops.add("/usr/bin/lpstat -h localhost -o '", queue_name),
-                      "' -p '"
-                    ),
-                    queue_name
-                  ),
-                  "'"
-                )
+                 "/usr/bin/lpstat -h localhost" +
+                 " -o " + queue_name.shellescape +
+                 " -p " + queue_name.shellescape
               )
               pending_job_info = Ops.get_string(Printerlib.result, "stdout", "")
             end
@@ -761,12 +745,7 @@ module Yast
                 _("Print testpage after the other jobs"),
                 :focus_no
               )
-              if !Printerlib.ExecuteBashCommand(
-                  Ops.add(
-                    Ops.add("/usr/bin/cancel -a -h localhost '", queue_name),
-                    "'"
-                  )
-                )
+              if !Printerlib.ExecuteBashCommand("/usr/bin/cancel -a -h localhost " + queue_name.shellescape)
                 Popup.ErrorDetails(
                   Builtins.sformat(
                     # where %1 will be replaced by the queue name.
@@ -813,23 +792,12 @@ module Yast
         # Do not enforce to talk to the cupsd on localhost when submiting the testpage
         # because testpage printing must also work for a "client-only" config.
         if !Printerlib.ExecuteBashCommand(
-            Ops.add(
-              Ops.add(
-                Ops.add(
-                  Ops.add(
-                    Ops.add(
-                      Ops.add(Ops.add("/usr/bin/lp -d '", queue_name), "' -t '"),
-                      testprint_job_title
-                    ),
-                    "' -o page-label=\""
-                  ),
-                  queue_name
-                ),
-                ":YaST2testprint@$(hostname)\" "
-              ),
-              testprint_file_name
-            )
-          )
+             "/usr/bin/lp -d " + queue_name.shellescape +
+             " -t " + testprint_job_title.shellescape +
+             " -o page-label=" + queue_name.shellescape +
+             "\":YaST2testprint@$(hostname)\" " +
+             testprint_file_name.shellescape
+           )
           Popup.ErrorDetails(
             Builtins.sformat(
               # where %1 will be replaced by the queue name.
@@ -885,32 +853,18 @@ module Yast
           # When this command fails for whatever reason, it is a safe fallback
           # to assume that there are no pending jobs in the queue:
           if Printerlib.ExecuteBashCommand(
-              Ops.add(
-                Ops.add(
-                  Ops.add(
-                    Ops.add("/usr/bin/lpstat -h localhost -o '", queue_name),
-                    "' | egrep -q '^"
-                  ),
-                  queue_name
-                ),
-                "-[0-9]+'"
-              )
-            )
+               "/usr/bin/lpstat -h localhost" +
+               " -o " + queue_name.shellescape +
+               " | egrep -q '^'" + queue_name.shellescape + "'-[0-9]+'"
+             )
             pending_job_info = _(
               "There are pending print jobs which might be deleted now."
             )
             if Printerlib.ExecuteBashCommand(
-                Ops.add(
-                  Ops.add(
-                    Ops.add(
-                      Ops.add("/usr/bin/lpstat -h localhost -o '", queue_name),
-                      "' -p '"
-                    ),
-                    queue_name
-                  ),
-                  "'"
-                )
-              )
+                 "/usr/bin/lpstat -h localhost" +
+                 " -o " + queue_name.shellescape +
+                 " -p " + queue_name.shellescape
+               )
               pending_job_info = Ops.get_string(Printerlib.result, "stdout", "")
             end
             if Popup.AnyQuestionRichText(
@@ -930,12 +884,7 @@ module Yast
                 _("Do not delete them"),
                 :focus_no
               )
-              if !Printerlib.ExecuteBashCommand(
-                  Ops.add(
-                    Ops.add("/usr/bin/cancel -a -h localhost '", queue_name),
-                    "'"
-                  )
-                )
+              if !Printerlib.ExecuteBashCommand("/usr/bin/cancel -a -h localhost " + queue_name.shellescape)
                 Popup.ErrorDetails(
                   Builtins.sformat(
                     # where %1 will be replaced by the queue name.
@@ -952,16 +901,8 @@ module Yast
               # when something is really wrong.
               # Sleep 1 second in any case to let the backend process terminate orderly:
               Builtins.sleep(1000)
-              backend_is_running_commandline = Ops.add(
-                Ops.add(
-                  Ops.add(
-                    Ops.add("ps -C '", uri_scheme),
-                    "' -o pid=,args= | grep '"
-                  ),
-                  testprint_job_title
-                ),
-                "'"
-              )
+              backend_is_running_commandline = "ps -C " + uri_scheme.shellescape + " -o pid=,args="
+              backend_is_running_commandline += " | grep " + testprint_job_title.shellescape
               # Do nothing to be on the safe side if the next command fails for whatever reason:
               if Printerlib.ExecuteBashCommand(backend_is_running_commandline)
                 # Sleep 10 seconds to give the backend process more time to terminate orderly
@@ -976,16 +917,12 @@ module Yast
                   )
                   # Kill the backend process:
                   Printerlib.ExecuteBashCommand(
-                    Ops.add(
-                      backend_is_running_commandline,
-                      " | cut -s -d ' ' -f1 | head -n 1 | tr -d -c '[:digit:]'"
-                    )
+                    backend_is_running_commandline +
+                    " | cut -s -d ' ' -f1 | head -n 1 | tr -d -c '[:digit:]'"
                   )
                   backend_pid = Ops.get_string(Printerlib.result, "stdout", "")
                   if "" != backend_pid
-                    Printerlib.ExecuteBashCommand(
-                      Ops.add(Ops.add("kill -9 '", backend_pid), "'")
-                    )
+                    Printerlib.ExecuteBashCommand("kill -9 " + backend_pid.shellescape)
                   end
                 end
               end
@@ -999,23 +936,15 @@ module Yast
               "'"
             )
             Printerlib.ExecuteBashCommand(
-              Ops.add(
-                Ops.add(
-                  Ops.add(
-                    Ops.add(
-                      #   echo ' funprinter-1000-123 ' | sed -e 's/.*-//'
-                      # so that it works even if there is a '-' in the queue name
-                      # which is not allowed but may happen nevertheless, see
-                      # http://bugzilla.novell.com/show_bug.cgi?id=556819#c12
-                      # and the final tr removes in particular spaces and newline:
-                      "echo '",
-                      test_print_command_stdout
-                    ), # sed is greedy and cuts all up to the last '-' for example
-                    "' | grep -o ' "
-                  ),
-                  queue_name
-                ),
-                "-[0-9]* ' | sed -e 's/.*-//' | tr -d -c '[:digit:]'"
+              #   echo funprinter-1000-123 | sed -e 's/.*-//'
+              # so that it works even if there is a '-' in the queue name
+              # which is not allowed but may happen nevertheless, see
+              # http://bugzilla.novell.com/show_bug.cgi?id=556819#c12
+              # and the final tr removes in particular spaces and newline:
+              "echo " + test_print_command_stdout.shellescape +
+              " | grep -o " + queue_name.shellescape + "'-[0-9]* '" +
+              " | sed -e 's/.*-//' | tr -d -c '[:digit:]'"
+              # sed is greedy and cuts all up to the last '-' for example
               )
             )
             test_print_job_number = Ops.get_string(
@@ -1026,10 +955,8 @@ module Yast
             test_print_cups_error_log = ""
             if "" != test_print_job_number
               Printerlib.ExecuteBashCommand(
-                Ops.add(
-                  Ops.add("grep '\\[Job ", test_print_job_number),
-                  "\\]' /var/log/cups/error_log | grep -v '^[dD]' | tail -n 20"
-                )
+                "grep '\\[Job '" + test_print_job_number.shellescape +
+                "'\\]' /var/log/cups/error_log | grep -v '^[dD]' | tail -n 20"
               )
               test_print_cups_error_log = Ops.add(
                 "...\n",
@@ -1108,9 +1035,7 @@ module Yast
             return nil
           end
           # Remove the 'ServerName' entry in /etc/cups/client.conf:
-          if !Printerlib.ExecuteBashCommand(
-              Ops.add(Printerlib.yast_bin_dir, "cups_client_only none")
-            )
+          if !Printerlib.ExecuteBashCommand(Printerlib.yast_bin_dir + "cups_client_only none")
             Popup.ErrorDetails(
               # Only a simple message because this error does not happen on a normal system
               # (i.e. a system which is not totally broken or totally messed up).

--- a/src/include/printer/overview.rb
+++ b/src/include/printer/overview.rb
@@ -24,6 +24,7 @@
 # Summary:     Overview dialog definition
 # Authors:     Johannes Meixner <jsmeix@suse.de>
 
+require "shellwords"
 require "yast2/system_time"
 
 module Yast

--- a/src/include/printer/overview.rb
+++ b/src/include/printer/overview.rb
@@ -23,8 +23,6 @@
 # Package:     Configuration of printer
 # Summary:     Overview dialog definition
 # Authors:     Johannes Meixner <jsmeix@suse.de>
-#
-# $Id: overview.ycp 29363 2006-03-24 08:20:43Z mzugec $
 
 require "yast2/system_time"
 

--- a/src/include/printer/policies.rb
+++ b/src/include/printer/policies.rb
@@ -147,9 +147,7 @@ module Yast
             Printerlib.client_conf_server_name
           )
         else
-          if !Printerlib.ExecuteBashCommand(
-              Ops.add(Printerlib.yast_bin_dir, "cups_client_only none")
-            )
+          if !Printerlib.ExecuteBashCommand(Printerlib.yast_bin_dir + "cups_client_only none")
             Popup.ErrorDetails(
               _(
                 "Failed to remove the 'ServerName' entry in /etc/cups/client.conf"
@@ -181,9 +179,7 @@ module Yast
       end
       # Determine the existing policy names in '<Policy policy-name>' sections in /etc/cups/cupsd.conf:
       policy_names = [""]
-      if Printerlib.ExecuteBashCommand(
-          Ops.add(Printerlib.yast_bin_dir, "modify_cupsd_conf Policies")
-        )
+      if Printerlib.ExecuteBashCommand(Printerlib.yast_bin_dir + "modify_cupsd_conf Policies")
         # but possible duplicate policy names are not removed in the command output:
         policy_names = Builtins.toset(
           Builtins.splitstring(
@@ -195,9 +191,7 @@ module Yast
         policy_names = ["default"]
       end
       # Determine the DefaultPolicy in /etc/cups/cupsd.conf:
-      if Printerlib.ExecuteBashCommand(
-          Ops.add(Printerlib.yast_bin_dir, "modify_cupsd_conf DefaultPolicy")
-        )
+      if Printerlib.ExecuteBashCommand(Printerlib.yast_bin_dir + "modify_cupsd_conf DefaultPolicy")
         # but possible duplicate policy names are not removed in the command output.
         # Multiple DefaultPolicy entries are a broken config but it can happen
         # and in this case the first DefaultPolicy entry is used:
@@ -221,9 +215,7 @@ module Yast
       # un-checked in any case:
       UI.ChangeWidget(Id("apply_operation_policy"), :Value, false)
       # Determine the ErrorPolicy in /etc/cups/cupsd.conf:
-      if Printerlib.ExecuteBashCommand(
-          Ops.add(Printerlib.yast_bin_dir, "modify_cupsd_conf ErrorPolicy")
-        )
+      if Printerlib.ExecuteBashCommand(Printerlib.yast_bin_dir + "modify_cupsd_conf ErrorPolicy")
         # but possible duplicate policy names are not removed in the command output.
         # Multiple ErrorPolicy entries are a broken config but it can happen
         # and in this case the first ErrorPolicy entry is used:
@@ -303,27 +295,12 @@ module Yast
         Builtins.foreach(Printer.queues) do |queue|
           name = Ops.get(queue, "name", "")
           next if "" == Builtins.filterchars(name, Printer.alnum_chars)
-          commandline = Ops.add(
-            Ops.add("/usr/sbin/lpadmin -h localhost -p '", name),
-            "'"
-          )
+          commandline = "/usr/sbin/lpadmin -h localhost -p " + name.shellescape
           if apply_operation_policy
-            commandline = Ops.add(
-              Ops.add(
-                Ops.add(commandline, " -o 'printer-op-policy="),
-                current_operation_policy
-              ),
-              "'"
-            )
+            commandline += " -o printer-op-policy=" + current_operation_policy.shellescape
           end
           if apply_error_policy
-            commandline = Ops.add(
-              Ops.add(
-                Ops.add(commandline, " -o 'printer-error-policy="),
-                current_error_policy
-              ),
-              "'"
-            )
+            commandline += " -o printer-error-policy=" + current_error_policy.shellescape
           end
           if !Printerlib.ExecuteBashCommand(commandline)
             Popup.ErrorDetails(
@@ -340,13 +317,7 @@ module Yast
       end
       if current_operation_policy != @initial_operation_policy
         if !Printerlib.ExecuteBashCommand(
-            Ops.add(
-              Ops.add(
-                Printerlib.yast_bin_dir,
-                "modify_cupsd_conf DefaultPolicy "
-              ),
-              current_operation_policy
-            )
+             Printerlib.yast_bin_dir + "modify_cupsd_conf DefaultPolicy " + current_operation_policy.shellescape
           )
           Popup.ErrorDetails(
             Builtins.sformat(
@@ -362,11 +333,8 @@ module Yast
       end
       if current_error_policy != @initial_error_policy
         if !Printerlib.ExecuteBashCommand(
-            Ops.add(
-              Ops.add(Printerlib.yast_bin_dir, "modify_cupsd_conf ErrorPolicy "),
-              current_error_policy
-            )
-          )
+             Printerlib.yast_bin_dir + "modify_cupsd_conf ErrorPolicy " + current_error_policy.shellescape
+           )
           Popup.ErrorDetails(
             Builtins.sformat(
               # where %1 will be replaced by the default error policy value.

--- a/src/include/printer/policies.rb
+++ b/src/include/printer/policies.rb
@@ -24,6 +24,8 @@
 # Summary:     DefaultPolicy and ErrorPolicy settings in cupsd.conf
 # Authors:     Johannes Meixner <jsmeix@suse.de>
 
+require "shellwords"
+
 module Yast
   module PrinterPoliciesInclude
     def initialize_printer_policies(include_target)

--- a/src/include/printer/policies.rb
+++ b/src/include/printer/policies.rb
@@ -23,8 +23,7 @@
 # Package:     Configuration of printer
 # Summary:     DefaultPolicy and ErrorPolicy settings in cupsd.conf
 # Authors:     Johannes Meixner <jsmeix@suse.de>
-#
-# $Id: policies.ycp 27914 2006-02-13 14:32:08Z locilka $
+
 module Yast
   module PrinterPoliciesInclude
     def initialize_printer_policies(include_target)

--- a/src/include/printer/printingvianetwork.rb
+++ b/src/include/printer/printingvianetwork.rb
@@ -24,6 +24,8 @@
 # Summary:     Printing via network dialog definition
 # Authors:     Johannes Meixner <jsmeix@suse.de>
 
+require "shellwords"
+
 module Yast
   module PrinterPrintingvianetworkInclude
     def initialize_printer_printingvianetwork(include_target)

--- a/src/include/printer/printingvianetwork.rb
+++ b/src/include/printer/printingvianetwork.rb
@@ -416,10 +416,7 @@ module Yast
             end
           end
           if !Printerlib.ExecuteBashCommand(
-              Ops.add(
-                Ops.add(Printerlib.yast_bin_dir, "cups_client_only "),
-                current_client_conf_value
-              )
+               Printerlib.yast_bin_dir + "cups_client_only " + current_client_conf_value.shellescape
             )
             if enforce_client_only_server_setting
               # In this case the cups_client_only tool fails in any case because it also tests accessibility.
@@ -448,7 +445,7 @@ module Yast
           end
           # Exit successfully by default and as fallback:
           return true
-        end 
+        end
         # A client-only config with effectively empty server name value continues here
         # and triggers the following "turn off client-only" case:
       end
@@ -472,9 +469,7 @@ module Yast
           return false
         end
         # Remove the 'ServerName' entry in /etc/cups/client.conf:
-        if !Printerlib.ExecuteBashCommand(
-            Ops.add(Printerlib.yast_bin_dir, "cups_client_only none")
-          )
+        if !Printerlib.ExecuteBashCommand(Printerlib.yast_bin_dir + "cups_client_only none")
           Popup.ErrorDetails(
             _(
               "Failed to remove the 'ServerName' entry in /etc/cups/client.conf"
@@ -482,7 +477,7 @@ module Yast
             Ops.get_string(Printerlib.result, "stderr", "")
           )
           return false
-        end 
+        end
         # The local cupsd is not started here because it is not clear at this point
         # if a local running cupsd is really needed. E.g. when both Browsing and BrowsePoll
         # are also disabled, there is no need to start the local cupsd in this dialog.
@@ -539,12 +534,7 @@ module Yast
               end
             end
             # An effectively non-empty current_browse_allow_value requires "Browsing On" in cupsd.conf:
-            if !Printerlib.ExecuteBashCommand(
-                Ops.add(
-                  Printerlib.yast_bin_dir,
-                  "modify_cupsd_conf Browsing On"
-                )
-              )
+            if !Printerlib.ExecuteBashCommand(Printerlib.yast_bin_dir + "modify_cupsd_conf Browsing On")
               Popup.ErrorDetails(
                 _("Failed to set 'Browsing On' in /etc/cups/cupsd.conf."),
                 Ops.get_string(Printerlib.result, "stderr", "")
@@ -553,16 +543,7 @@ module Yast
             end
             # Write the BrowseAllow values to cupsd.conf:
             if !Printerlib.ExecuteBashCommand(
-                Ops.add(
-                  Ops.add(
-                    Ops.add(
-                      Printerlib.yast_bin_dir,
-                      "modify_cupsd_conf BrowseAllow '"
-                    ),
-                    current_browse_allow_value
-                  ),
-                  "'"
-                )
+                 Printerlib.yast_bin_dir + "modify_cupsd_conf BrowseAllow " + current_browse_allow_value.shellescape
               )
               Popup.ErrorDetails(
                 # where %1 will be replaced by the values for BrowseAllow.
@@ -588,12 +569,7 @@ module Yast
         # because "Browsing Off" disables also sharing of local printers
         # which might be needed by the "Share Printers" dialog.
         # Instead set only "BrowseAllow none" in cupsd.conf:
-        if !Printerlib.ExecuteBashCommand(
-            Ops.add(
-              Printerlib.yast_bin_dir,
-              "modify_cupsd_conf BrowseAllow none"
-            )
-          )
+        if !Printerlib.ExecuteBashCommand(Printerlib.yast_bin_dir + "modify_cupsd_conf BrowseAllow none")
           Popup.ErrorDetails(
             _("Failed to set 'BrowseAllow none' in /etc/cups/cupsd.conf."),
             Ops.get_string(Printerlib.result, "stderr", "")
@@ -629,12 +605,7 @@ module Yast
                 current_browse_poll_value,
                 Printer.alnum_chars
               )
-            if !Printerlib.ExecuteBashCommand(
-                Ops.add(
-                  Printerlib.yast_bin_dir,
-                  "modify_cupsd_conf Browsing On"
-                )
-              )
+            if !Printerlib.ExecuteBashCommand(Printerlib.yast_bin_dir + "modify_cupsd_conf Browsing On")
               Popup.ErrorDetails(
                 _("Failed to set 'Browsing On' in /etc/cups/cupsd.conf."),
                 Ops.get_string(Printerlib.result, "stderr", "")
@@ -643,17 +614,8 @@ module Yast
             end
             # Write the BrowsePoll values to cupsd.conf:
             if !Printerlib.ExecuteBashCommand(
-                Ops.add(
-                  Ops.add(
-                    Ops.add(
-                      Printerlib.yast_bin_dir,
-                      "modify_cupsd_conf BrowsePoll '"
-                    ),
-                    current_browse_poll_value
-                  ),
-                  "'"
-                )
-              )
+                 Printerlib.yast_bin_dir + "modify_cupsd_conf BrowsePoll " + current_browse_poll_value.shellescape
+               )
               Popup.ErrorDetails(
                 # where %1 will be replaced by the values for BrowsePoll.
                 Builtins.sformat(
@@ -675,12 +637,7 @@ module Yast
         # but now the user has deactivated it
         # so that the BrowsePoll config should be disabled:
         # Set only "BrowsePoll none" in cupsd.conf:
-        if !Printerlib.ExecuteBashCommand(
-            Ops.add(
-              Printerlib.yast_bin_dir,
-              "modify_cupsd_conf BrowsePoll none"
-            )
-          )
+        if !Printerlib.ExecuteBashCommand(Printerlib.yast_bin_dir + "modify_cupsd_conf BrowsePoll none")
           Popup.ErrorDetails(
             _("Failed to set 'BrowsePoll none' in /etc/cups/cupsd.conf"),
             Ops.get_string(Printerlib.result, "stderr", "")
@@ -853,7 +810,7 @@ module Yast
           :Value,
           Id(:browse_allow_all)
         )
-        @initial_browse_allow = :browse_allow_all 
+        @initial_browse_allow = :browse_allow_all
         # If browsing info is accepted from "all" hosts
         # it would be useless to additionally accept it from specific IPs or networks.
       end
@@ -872,7 +829,7 @@ module Yast
           :Value,
           Id(:browse_allow_none)
         )
-        @initial_browse_allow = :browse_allow_none 
+        @initial_browse_allow = :browse_allow_none
         # If browsing info is accepted from "none" hosts
         # it would be contradicting to additionally accept it from specific IPs or networks.
       end
@@ -1100,7 +1057,7 @@ module Yast
         end
         if :next == Ops.get(event, "ID")
           if !ApplyNetworkPrintingSettings()
-            Popup.Error(_("Failed to apply the settings to the system.")) 
+            Popup.Error(_("Failed to apply the settings to the system."))
             # In case of an error stay on the "Print via Network" dialog
             # so that the user can either change his settings until it works
             # or he can use the [Cancel] button to return to the Overview dialog:

--- a/src/include/printer/printingvianetwork.rb
+++ b/src/include/printer/printingvianetwork.rb
@@ -23,8 +23,7 @@
 # Package:     Configuration of printer
 # Summary:     Printing via network dialog definition
 # Authors:     Johannes Meixner <jsmeix@suse.de>
-#
-# $Id: printingvianetwork.ycp 27914 2006-02-13 14:32:08Z locilka $
+
 module Yast
   module PrinterPrintingvianetworkInclude
     def initialize_printer_printingvianetwork(include_target)

--- a/src/include/printer/readwrite.rb
+++ b/src/include/printer/readwrite.rb
@@ -23,8 +23,7 @@
 # Package:     Configuration of printer
 # Summary:     Read and write dialogs definitions
 # Authors:     Johannes Meixner <jsmeix@suse.de>
-#
-# $Id: readwrite.ycp 29363 2006-03-24 08:20:43Z mzugec $
+
 module Yast
   module PrinterReadwriteInclude
     def initialize_printer_readwrite(include_target)

--- a/src/include/printer/sharing.rb
+++ b/src/include/printer/sharing.rb
@@ -348,7 +348,7 @@ module Yast
             )
           end
         end
-      end 
+      end
 
       if allow_local_network_access
         allow_values = Ops.add("@LOCAL ", allow_values)
@@ -386,12 +386,7 @@ module Yast
         # but Allow and BrowseAddress enties would be kept because when there are
         # BrowseAddress enties, it must listen on matching remote interfaces
         # and then also matching Allow enties should be there.
-        if !Printerlib.ExecuteBashCommand(
-            Ops.add(
-              Printerlib.yast_bin_dir,
-              "modify_cupsd_conf Listen localhost"
-            )
-          )
+        if !Printerlib.ExecuteBashCommand(Printerlib.yast_bin_dir + "modify_cupsd_conf Listen localhost")
           Popup.ErrorDetails(
             # Do not change or translate "Listen localhost", it is a system settings name.
             _("Failed to set only 'Listen localhost' in /etc/cups/cupsd.conf."),
@@ -399,9 +394,7 @@ module Yast
           )
           return false
         end
-        if !Printerlib.ExecuteBashCommand(
-            Ops.add(Printerlib.yast_bin_dir, "modify_cupsd_conf Allow none")
-          )
+        if !Printerlib.ExecuteBashCommand(Printerlib.yast_bin_dir + "modify_cupsd_conf Allow none")
           Popup.ErrorDetails(
             # Do not change or translate "Allow", it is a system settings name.
             _("Failed to remove 'Allow' entries from /etc/cups/cupsd.conf."),
@@ -414,12 +407,7 @@ module Yast
         # of remote queue information from remote CUPS servers
         # which might be needed by the "Print Via Network" dialog.
         # Instead remove only the "BrowseAddress" entries in cupsd.conf:
-        if !Printerlib.ExecuteBashCommand(
-            Ops.add(
-              Printerlib.yast_bin_dir,
-              "modify_cupsd_conf BrowseAddress none"
-            )
-          )
+        if !Printerlib.ExecuteBashCommand(Printerlib.yast_bin_dir + "modify_cupsd_conf BrowseAddress none")
           Popup.ErrorDetails(
             # Do not change or translate "BrowseAddress", it is a system settings name.
             _(
@@ -463,7 +451,7 @@ module Yast
             Ops.get_string(initial_interface_table_item, 2, "")
           )
         )
-      end 
+      end
 
       initial_interface_table_entries = Builtins.toset(
         initial_interface_table_entries
@@ -477,7 +465,7 @@ module Yast
             Ops.get_string(interface_table_item, 2, "")
           )
         )
-      end 
+      end
 
       interface_table_entries = Builtins.toset(interface_table_entries)
       if Builtins.mergestring(interface_table_entries, "") !=
@@ -522,14 +510,8 @@ module Yast
         end
       end
       if !Printerlib.ExecuteBashCommand(
-          Ops.add(
-            Ops.add(
-              Ops.add(Printerlib.yast_bin_dir, "modify_cupsd_conf Allow '"),
-              allow_values
-            ),
-            "'"
-          )
-        )
+           Printerlib.yast_bin_dir + "modify_cupsd_conf Allow " + allow_values.shellescape
+         )
         Popup.ErrorDetails(
           Builtins.sformat(
             # where %1 will be replaced by one or more system settings values.
@@ -543,17 +525,8 @@ module Yast
       end
       if "" != browse_address_values
         if !Printerlib.ExecuteBashCommand(
-            Ops.add(
-              Ops.add(
-                Ops.add(
-                  Printerlib.yast_bin_dir,
-                  "modify_cupsd_conf BrowseAddress '"
-                ),
-                browse_address_values
-              ),
-              "'"
-            )
-          )
+             Printerlib.yast_bin_dir + "modify_cupsd_conf BrowseAddress " + browse_address_values.shellescape
+           )
           Popup.ErrorDetails(
             Builtins.sformat(
               # where %1 will be replaced by one or more system settings values.
@@ -569,9 +542,7 @@ module Yast
         end
         # Having "BrowseAddress" entries requires "Browsing On",
         # otherwise browsing information would not be sent at all:
-        if !Printerlib.ExecuteBashCommand(
-            Ops.add(Printerlib.yast_bin_dir, "modify_cupsd_conf Browsing On")
-          )
+        if !Printerlib.ExecuteBashCommand(Printerlib.yast_bin_dir + "modify_cupsd_conf Browsing On")
           Popup.ErrorDetails(
             _("Failed to set 'Browsing On' in /etc/cups/cupsd.conf."),
             Ops.get_string(Printerlib.result, "stderr", "")
@@ -584,12 +555,7 @@ module Yast
         # of remote queue information from remote CUPS servers
         # which might be needed by the "Print Via Network" dialog.
         # Instead remove only the "BrowseAddress" entries in cupsd.conf:
-        if !Printerlib.ExecuteBashCommand(
-            Ops.add(
-              Printerlib.yast_bin_dir,
-              "modify_cupsd_conf BrowseAddress none"
-            )
-          )
+        if !Printerlib.ExecuteBashCommand(Printerlib.yast_bin_dir + "modify_cupsd_conf BrowseAddress none")
           Popup.ErrorDetails(
             # Do not change or translate "BrowseAddress", it is a system settings name.
             _(
@@ -606,9 +572,7 @@ module Yast
       # Neither 'Listen @LOCAL' nor 'Listen @IF(name)' is supported.
       # TODO: Determine the matching network address for @LOCAL and @IF(name)
       #       and use the matching network address for the Listen directive.
-      if !Printerlib.ExecuteBashCommand(
-          Ops.add(Printerlib.yast_bin_dir, "modify_cupsd_conf Listen all")
-        )
+      if !Printerlib.ExecuteBashCommand(Printerlib.yast_bin_dir + "modify_cupsd_conf Listen all")
         Popup.ErrorDetails(
           # Do not change or translate "Listen *:631", it is a system settings name.
           _("Failed to set 'Listen *:631' in /etc/cups/cupsd.conf."),
@@ -651,9 +615,7 @@ module Yast
             Printerlib.client_conf_server_name
           )
         else
-          if !Printerlib.ExecuteBashCommand(
-              Ops.add(Printerlib.yast_bin_dir, "cups_client_only none")
-            )
+          if !Printerlib.ExecuteBashCommand(Printerlib.yast_bin_dir + "cups_client_only none")
             Popup.ErrorDetails(
               _(
                 "Failed to remove the 'ServerName' entry in /etc/cups/client.conf"
@@ -716,9 +678,7 @@ module Yast
       # Therefore "modify_cupsd_conf Listen" reports 'localhost' but ignores '/var/run/cups/cups.sock'
       # so that ["localhost"] is the right fallback value here:
       listen_values = [""]
-      if Printerlib.ExecuteBashCommand(
-          Ops.add(Printerlib.yast_bin_dir, "modify_cupsd_conf Listen")
-        )
+      if Printerlib.ExecuteBashCommand(Printerlib.yast_bin_dir +"modify_cupsd_conf Listen")
         # but possible duplicate Listen values are not removed in the command output:
         listen_values = Builtins.toset(
           Builtins.splitstring(
@@ -746,7 +706,7 @@ module Yast
             listen_remote = true
           end
         end
-      end 
+      end
 
       if !listen_local
         # (e.g. listen only on /var/run/cups/cups.sock is a broken config)
@@ -762,18 +722,14 @@ module Yast
         # Only while this dialog is open, the non-'localhost' Listen entries are removed
         # which means that there is no remote access while this dialog is open
         # which is no big issue for a broken config without any local access ;-)
-        Printerlib.ExecuteBashCommand(
-          Ops.add(Printerlib.yast_bin_dir, "modify_cupsd_conf Listen localhost")
-        )
+        Printerlib.ExecuteBashCommand(Printerlib.yast_bin_dir + "modify_cupsd_conf Listen localhost")
         Printerlib.GetAndSetCupsdStatus("restart")
       end
       # Determine the 'Allow' values for the root location '<Location />' in /etc/cups/cupsd.conf:
       # By default there is only 'Allow 127.0.0.2' but this value is suppressed in the output
       # of 'modify_cupsd_conf Allow' so that the empty sting is the right fallback value here:
       allow_values = [""]
-      if Printerlib.ExecuteBashCommand(
-          Ops.add(Printerlib.yast_bin_dir, "modify_cupsd_conf Allow")
-        )
+      if Printerlib.ExecuteBashCommand(Printerlib.yast_bin_dir + "modify_cupsd_conf Allow")
         # but possible duplicate Allow values are not removed in the command output:
         allow_values = Builtins.toset(
           Builtins.splitstring(
@@ -788,9 +744,7 @@ module Yast
       # Determine the 'BrowseAddress' values in /etc/cups/cupsd.conf:
       # By default there is no BrowseAddress value so that the empty sting is the right fallback:
       browse_address_values = [""]
-      if Printerlib.ExecuteBashCommand(
-          Ops.add(Printerlib.yast_bin_dir, "modify_cupsd_conf BrowseAddress")
-        )
+      if Printerlib.ExecuteBashCommand(Printerlib.yast_bin_dir + "modify_cupsd_conf BrowseAddress")
         # but possible duplicate BrowseAddress values are not removed in the command output:
         browse_address_values = Builtins.toset(
           Builtins.splitstring(
@@ -878,7 +832,7 @@ module Yast
           Ops.add(@initial_allow_input_value, allow_value),
           " "
         )
-      end 
+      end
 
       # By default initial_deny_remote_access is true
       # and initial_allow_remote_access is false (see above)
@@ -930,7 +884,7 @@ module Yast
           Ops.add(@initial_browse_address_input_value, browse_address_value),
           " "
         )
-      end 
+      end
 
       Builtins.y2milestone(
         "Initial interface_table_items: %1",
@@ -1084,7 +1038,7 @@ module Yast
                     )
                   )
                 end
-              end 
+              end
 
               if !@is_in_table
                 Builtins.y2milestone("Adding interface_map %1", @interface_map)
@@ -1149,7 +1103,7 @@ module Yast
                     )
                   )
                 end
-              end 
+              end
 
               UI.ChangeWidget(:interface_table, :Items, @interface_table_items)
               UI.ChangeWidget(:interface_table, :CurrentItem, @current_item)
@@ -1183,7 +1137,7 @@ module Yast
                     interface_table_item
                   )
                 end
-              end 
+              end
 
               UI.ChangeWidget(:interface_table, :Items, @interface_table_items)
             else

--- a/src/include/printer/sharing.rb
+++ b/src/include/printer/sharing.rb
@@ -678,7 +678,7 @@ module Yast
       # Therefore "modify_cupsd_conf Listen" reports 'localhost' but ignores '/var/run/cups/cups.sock'
       # so that ["localhost"] is the right fallback value here:
       listen_values = [""]
-      if Printerlib.ExecuteBashCommand(Printerlib.yast_bin_dir +"modify_cupsd_conf Listen")
+      if Printerlib.ExecuteBashCommand(Printerlib.yast_bin_dir + "modify_cupsd_conf Listen")
         # but possible duplicate Listen values are not removed in the command output:
         listen_values = Builtins.toset(
           Builtins.splitstring(

--- a/src/include/printer/sharing.rb
+++ b/src/include/printer/sharing.rb
@@ -24,6 +24,8 @@
 # Summary:     Print queue sharing and publishing dialog definition
 # Authors:     Johannes Meixner <jsmeix@suse.de>
 
+require "shellwords"
+
 module Yast
   module PrinterSharingInclude
     def initialize_printer_sharing(include_target)

--- a/src/include/printer/sharing.rb
+++ b/src/include/printer/sharing.rb
@@ -23,8 +23,7 @@
 # Package:     Configuration of printer
 # Summary:     Print queue sharing and publishing dialog definition
 # Authors:     Johannes Meixner <jsmeix@suse.de>
-#
-# $Id: sharing.ycp 27914 2006-02-13 14:32:08Z locilka $
+
 module Yast
   module PrinterSharingInclude
     def initialize_printer_sharing(include_target)

--- a/src/include/printer/wizards.rb
+++ b/src/include/printer/wizards.rb
@@ -23,8 +23,7 @@
 # Package:     Configuration of printer
 # Summary:     Wizards definitions
 # Authors:     Johannes Meixner <jsmeix@suse.de>
-#
-# $Id: wizards.ycp 27914 2006-02-13 14:32:08Z locilka $
+
 module Yast
   module PrinterWizardsInclude
     def initialize_printer_wizards(include_target)

--- a/src/modules/Printer.rb
+++ b/src/modules/Printer.rb
@@ -24,8 +24,6 @@
 # Summary:     Printer settings, input and output functions
 # Authors:     Johannes Meixner <jsmeix@suse.de>
 #
-# $Id: Printer.ycp 27914 2006-02-13 14:32:08Z locilka $
-#
 # Representation of the configuration of printer.
 # Input and output routines.
 require "yast"

--- a/src/modules/Printer.rb
+++ b/src/modules/Printer.rb
@@ -305,7 +305,7 @@ module Yast
       @autodetect_queues_commandline = "/usr/lib/YaST2/bin/autodetect_print_queues >" + @autodetected_queues_filename
       @driver_options_filename = "/var/lib/YaST2/printer_driver_options.ycp"
       @determine_printer_driver_options_commandline =
-        "/usr/lib/YaST2/bin/determine_printer_driver_options >" + @driver_options_filename
+        "/usr/lib/YaST2/bin/determine_printer_driver_options >" + @driver_options_filename + " "
     end
 
     # Abort function

--- a/src/modules/Printer.rb
+++ b/src/modules/Printer.rb
@@ -296,32 +296,16 @@ module Yast
       # Local variables:
       @create_database_progress_filename = "/var/lib/YaST2/create_printer_ppd_database.progress"
       @database_filename = "/var/lib/YaST2/printer_ppd_database.ycp"
-      @create_database_commandline = Ops.add(
-        "/usr/lib/YaST2/bin/create_printer_ppd_database >",
-        @database_filename
-      )
+      @create_database_commandline = "/usr/lib/YaST2/bin/create_printer_ppd_database >" + @database_filename
       @autodetect_printers_progress_filename = "/var/lib/YaST2/autodetect_printers.progress"
       @autodetected_printers_filename = "/var/lib/YaST2/autodetected_printers.ycp"
-      @autodetect_printers_commandline = Ops.add(
-        Ops.add(
-          Ops.add("export PROGRESS=", @autodetect_printers_progress_filename),
-          " ; /usr/lib/YaST2/bin/autodetect_printers >"
-        ),
-        @autodetected_printers_filename
-      )
+      @autodetect_printers_commandline = "export PROGRESS=" + @autodetect_printers_progress_filename +
+        " ; /usr/lib/YaST2/bin/autodetect_printers >" + @autodetected_printers_filename
       @autodetected_queues_filename = "/var/lib/YaST2/autodetected_print_queues.ycp"
-      @autodetect_queues_commandline = Ops.add(
-        "/usr/lib/YaST2/bin/autodetect_print_queues >",
-        @autodetected_queues_filename
-      )
+      @autodetect_queues_commandline = "/usr/lib/YaST2/bin/autodetect_print_queues >" + @autodetected_queues_filename
       @driver_options_filename = "/var/lib/YaST2/printer_driver_options.ycp"
-      @determine_printer_driver_options_commandline = Ops.add(
-        Ops.add(
-          "/usr/lib/YaST2/bin/determine_printer_driver_options >",
-          @driver_options_filename
-        ),
-        " "
-      )
+      @determine_printer_driver_options_commandline =
+        "/usr/lib/YaST2/bin/determine_printer_driver_options >" + @driver_options_filename
     end
 
     # Abort function
@@ -354,9 +338,7 @@ module Yast
       if progress_feedback
         # Empty an existing progress file so that the DownloadProgress starts at the beginning.
         # Don't care if this command is successful. All what matters is if CreateDatabase() works.
-        Printerlib.ExecuteBashCommand(
-          Ops.add("cat /dev/null >", @create_database_progress_filename)
-        )
+        Printerlib.ExecuteBashCommand("cat /dev/null >" + @create_database_progress_filename)
         UI.OpenDialog(
           MinSize(
             60,
@@ -478,9 +460,7 @@ module Yast
       if progress_feedback
         # Empty an existing progress file so that the DownloadProgress starts at the beginning.
         # Don't care if this command is successful.
-        Printerlib.ExecuteBashCommand(
-          Ops.add("cat /dev/null >", @autodetect_printers_progress_filename)
-        )
+        Printerlib.ExecuteBashCommand("cat /dev/null >" + @autodetect_printers_progress_filename)
         UI.OpenDialog(
           MinSize(
             60,
@@ -664,11 +644,9 @@ module Yast
         end
       end
       return false if "" == queue_name
-      commandline = Ops.add(
-        @determine_printer_driver_options_commandline,
-        queue_name
-      )
-      if !Printerlib.ExecuteBashCommand(commandline)
+      if !Printerlib.ExecuteBashCommand(
+           @determine_printer_driver_options_commandline + queue_name.shellescape
+         )
         Popup.ErrorDetails(
           Builtins.sformat(
             # Only a simple message because this error does not happen on a normal system
@@ -831,7 +809,7 @@ module Yast
             words_start_with_known_manufacturer = true
             raise Break
           end
-        end 
+        end
 
         if 1 == max_words || 2 == max_words
           if words_start_with_known_manufacturer
@@ -978,7 +956,7 @@ module Yast
             Ops.set(words, 0, Ops.add("^", Ops.get(words, 0, "")))
             raise Break
           end
-        end 
+        end
 
         # Concatenate the words by the regular expression '.*' so that the search result
         # could hopefully fit better to what the user actually expects to get,
@@ -1074,7 +1052,7 @@ module Yast
             try_again = true
             raise Break
           end
-        end 
+        end
 
         # Avoid an endless loop:
         if Ops.greater_than(trailing_number, 10000)
@@ -1153,7 +1131,7 @@ module Yast
             @selected_queues_index = queues_index if @current_queue_name == name
           end
         end
-      end 
+      end
 
       # Show a fallback text if there are no queues:
       if Ops.less_than(Builtins.size(queue_items), 1)
@@ -1202,7 +1180,7 @@ module Yast
               connection
             )
           end
-        end 
+        end
 
         # AutodetectPrinters overwrites the existing connections list:
         if !AutodetectPrinters()
@@ -1238,7 +1216,7 @@ module Yast
             Builtins.substring(Ops.get(connection_entry, "uri", ""), 0, 10)
           parallel_uri_exists = true
         end
-      end 
+      end
 
       # Make a list of uri, model, and info entries of the connections
       # and take the connection_filter_string into account (if it is not the empty string).
@@ -1414,7 +1392,7 @@ module Yast
             @selected_connections_index = connections_index
           end
         end
-      end 
+      end
 
       # Sort the list according to the model:
       # connection_item[0] is `id(connections_index)
@@ -1581,7 +1559,7 @@ module Yast
             driver_items << Item(Id(ppds_index), driver_string)
           end
         end
-      end 
+      end
 
       if Builtins.size(driver_items) == 0
         # show a meaningful text as fallback entry ('Find More' is a button label).
@@ -1631,7 +1609,7 @@ module Yast
           selected_driver_items_index = driver_items_index
           raise Break
         end
-      end 
+      end
 
       if preselection && Ops.greater_or_equal(selected_driver_items_index, 0)
         # driver_items[selected_driver_items_index] is a driver_item and
@@ -1808,7 +1786,7 @@ module Yast
               raise Break
             end
           end
-        end 
+        end
 
         if Ops.greater_or_equal(driver_items_index, 0)
           Builtins.y2milestone(
@@ -2028,29 +2006,12 @@ module Yast
         @current_device_uri = ""
         return false
       end
-      # Note the bash quotings of the parameters with ' characters:
-      commandline = Ops.add(
-        Ops.add(
-          Ops.add(
-            Ops.add(
-              Ops.add(
-                Ops.add(
-                  Ops.add(
-                    Ops.add("/usr/sbin/lpadmin -h localhost -p '", queue_name),
-                    "' -v '"
-                  ),
-                  uri
-                ),
-                "' -m '"
-              ),
-              ppd
-            ),
-            "' -D '"
-          ),
-          description
-        ),
-        "' -E"
-      )
+      commandline = "/usr/sbin/lpadmin -h localhost"
+      commandline += " -p " + queue_name.shellescape
+      commandline += " -v " + uri.shellescape
+      commandline += " -m " + ppd.shellescape
+      commandline += " -D " + description.shellescape
+      commandline += " -E"
       if !Printerlib.ExecuteBashCommand(commandline)
         Popup.ErrorDetails(
           Builtins.sformat(
@@ -2070,12 +2031,7 @@ module Yast
         # Because this AddQueue function is only used to add a not-yet-existing queue,
         # it is safe to try to remove the queue in any case if the setup had failed
         # but ignore any possible errors here (e.g. when the queue does not exist).
-        Printerlib.ExecuteBashCommand(
-          Ops.add(
-            Ops.add("/usr/sbin/lpadmin -h localhost -x '", queue_name),
-            "'"
-          )
-        )
+        Printerlib.ExecuteBashCommand("/usr/sbin/lpadmin -h localhost -x " + queue_name.shellescape)
         @current_queue_name = ""
         @current_device_uri = ""
         return false
@@ -2083,13 +2039,10 @@ module Yast
       # If the new queue was created successfully, make it the default queue if this is requested:
       if is_default_queue
         # with other option settings so that a separate lpadmin command is called:
-        commandline = Ops.add(
-          Ops.add("/usr/sbin/lpadmin -h localhost -d '", queue_name),
-          "'"
-        )
+
         # Do not care if it fails to make it the default queue (i.e. show no error message to the user)
-        # because the default queue setting is nice to have but not mandatoty for a working queue:
-        Printerlib.ExecuteBashCommand(commandline)
+        # because the default queue setting is nice to have but not mandatory for a working queue:
+        Printerlib.ExecuteBashCommand("/usr/sbin/lpadmin -h localhost -d " + queue_name.shellescape)
       end
       # Try to set the requested default_paper_size if it is an available choice for this queue.
       # If no default_paper_size is requested, the CUPS default is used.
@@ -2108,27 +2061,13 @@ module Yast
         # (a queue with a "System V style interface script" cannot be set up with YaST).
         # '\>' is used to find an available choice also when it is the last value on the line.
         # Note the YCP quoting: \\< becomes \< and \\> becomes \> in the commandline.
-        commandline = Ops.add(
-          Ops.add(
-            Ops.add(
-              Ops.add("lpoptions -h localhost -p '", queue_name),
-              "' -l | grep '^PageSize.*\\<"
-            ),
-            default_paper_size
-          ),
-          "\\>'"
-        )
+        commandline = "lpoptions -h localhost -p " + queue_name.shellescape
+        commandline += " -l"
+        commandline += " | grep '^PageSize.*\\<'" + default_paper_size.shellescape + "'\\>'"
         if Printerlib.ExecuteBashCommand(commandline)
-          commandline = Ops.add(
-            Ops.add(
-              Ops.add(
-                Ops.add("/usr/sbin/lpadmin -h localhost -p '", queue_name),
-                "' -o 'PageSize="
-              ),
-              default_paper_size
-            ),
-            "'"
-          )
+          commandline = "/usr/sbin/lpadmin -h localhost"
+          commandline += " -p " + queue_name.shellescape
+          commandline += " -o PageSize=" + default_paper_size.shellescape
           # Do not care if it fails to set the default_paper_size (i.e. show no error message to the user)
           # because the default_paper_size setting is nice to have but not mandatoty for a working queue:
           Printerlib.ExecuteBashCommand(commandline)
@@ -2166,12 +2105,7 @@ module Yast
         )
         return false
       end
-      # Note the bash quoting of the queue_name string with ' characters:
-      commandline = Ops.add(
-        Ops.add("/usr/sbin/lpadmin -h localhost -x '", queue_name),
-        "'"
-      )
-      if !Printerlib.ExecuteBashCommand(commandline)
+      if !Printerlib.ExecuteBashCommand("/usr/sbin/lpadmin -h localhost -x " + queue_name.shellescape)
         Popup.ErrorDetails(
           Builtins.sformat(
             # Only a simple message because this error does not happen on a normal system
@@ -2291,7 +2225,7 @@ module Yast
               end
               value_items_list = Builtins.add(value_items_list, Item(value))
             end
-          end 
+          end
 
 
           if "" != currently_selected_value
@@ -2314,7 +2248,7 @@ module Yast
             Item(Id(keyword), option_name, opened, value_items_list)
           )
         end
-      end 
+      end
 
       # Have the PageSize option topmost:
       if Ops.greater_or_equal(pagesize_option_index, 0)
@@ -2352,7 +2286,10 @@ module Yast
          "127.0" == Builtins.substring(server_name, 0, 5)
         return Printerlib.GetAndSetCupsdStatus("start")
 
-      elsif Printerlib.ExecuteBashCommand("( echo -n '' >/dev/tcp/"+ server_name +"/631 ) & ECHO_PID=$! ; sleep 2s ; kill $ECHO_PID &>/dev/null ; wait $ECHO_PID")
+      elsif Printerlib.ExecuteBashCommand(
+              "( echo -n '' >/dev/tcp/" + server_name.shellescape + "/631 ) & ECHO_PID=$!" +
+              " ; sleep 2s ; kill $ECHO_PID &>/dev/null ; wait $ECHO_PID"
+            )
         return true
       else
         Popup.Error(_("The server '" + server_name + "' is not available or not listening on port 631"))
@@ -2389,9 +2326,7 @@ module Yast
         _(
           "Launched hp-setup.\nYou must finish hp-setup before you can proceed with the printer configuration.\n"
         )
-      if !Printerlib.ExecuteBashCommand(
-          Ops.add(Printerlib.yast_bin_dir, "basicadd_displaytest")
-        )
+      if !Printerlib.ExecuteBashCommand(Printerlib.yast_bin_dir + "basicadd_displaytest")
         # because it would run without any contact to the user "in the background"
         # while in the foreground YaST waits for hp-setup to be finished
         # which is imposible for the user so that the result is a deadlock.

--- a/src/modules/Printer.rb
+++ b/src/modules/Printer.rb
@@ -26,6 +26,8 @@
 #
 # Representation of the configuration of printer.
 # Input and output routines.
+
+require "shellwords"
 require "yast"
 
 module Yast

--- a/src/modules/Printerlib.rb
+++ b/src/modules/Printerlib.rb
@@ -25,6 +25,7 @@
 # Authors:     Michal Zugec <mzugec@suse.cz>
 #              Johannes Meixner <jsmeix@suse.de>
 
+require "shellwords"
 require "yast"
 
 module Yast

--- a/src/modules/Printerlib.rb
+++ b/src/modules/Printerlib.rb
@@ -143,7 +143,7 @@ module Yast
       # because alternatives would be handled in the upper-level functions
       # (e.g. in the user dialogs) which call TestAndInstallPackage:
       if "installed" == action
-        if ExecuteBashCommand(Ops.add(Ops.add("rpm -q '", package_name), "'"))
+        if ExecuteBashCommand("rpm -q " + package_name.shellescape)
           Builtins.y2milestone(
             "TestAndInstallPackage: package '%1' is installed",
             Ops.get_string(@result, "stdout", package_name)
@@ -159,7 +159,7 @@ module Yast
         return false
       end
       if "install" == action
-        if ExecuteBashCommand(Ops.add(Ops.add("rpm -q '", package_name), "'"))
+        if ExecuteBashCommand("rpm -q " + package_name.shellescape)
           Builtins.y2milestone(
             "TestAndInstallPackage: package '%1' is already installed",
             Ops.get_string(@result, "stdout", package_name)
@@ -228,7 +228,7 @@ module Yast
         end
       end
       if "remove" == action
-        if !ExecuteBashCommand(Ops.add(Ops.add("rpm -q '", package_name), "'"))
+        if !ExecuteBashCommand("rpm -q " + package_name.shellescape)
           Builtins.y2milestone(
             "TestAndInstallPackage: skip remove because %1",
             Ops.get_string(@result, "stdout", "package is not installed")
@@ -268,9 +268,7 @@ module Yast
         # Therefore there is a test if the removal would break RPM dependencies
         # but intentionally it is not tested whether the removal
         # would "break" whatever kind of soft requirements (Recommends).
-        if !ExecuteBashCommand(
-            Ops.add(Ops.add("rpm -e --test '", package_name), "'")
-          )
+        if !ExecuteBashCommand("rpm -e --test " + package_name.shellescape)
           # Therefore the exact RPM message is shown via a separated Popup::ErrorDetails.
           Popup.ErrorDetails(
             Builtins.sformat(
@@ -295,9 +293,7 @@ module Yast
             return false
           end
         end
-        if !ExecuteBashCommand(
-            Ops.add(Ops.add("rpm -e --nodeps '", package_name), "'")
-          )
+        if !ExecuteBashCommand("rpm -e --nodeps " + package_name.shellescape)
           Builtins.y2milestone(
             "TestAndInstallPackage: Failed to remove package %1.",
             package_name
@@ -387,7 +383,7 @@ module Yast
           Popup.ErrorDetails(
             _("Failed to enable starting of the CUPS daemon during system boot"),
             Service.Error
-          ) 
+          )
           # This is not a fatal error, therefore return "successfully" nevertheless.
         end
         return true
@@ -446,7 +442,7 @@ module Yast
                   "Failed to enable starting of the CUPS daemon during system boot"
                 ),
                 Service.Error
-              ) 
+              )
               # This is not a fatal error, therefore return "successfully" nevertheless.
             end
           end
@@ -487,7 +483,7 @@ module Yast
     end
 
     def DetermineClientOnly
-      if ExecuteBashCommand(Ops.add(@yast_bin_dir, "cups_client_only"))
+      if ExecuteBashCommand(@yast_bin_dir + "cups_client_only")
         @client_conf_server_name = Ops.get_string(@result, "stdout", "")
         if "" != @client_conf_server_name &&
             "localhost" != @client_conf_server_name &&
@@ -537,9 +533,7 @@ module Yast
     end
 
     def DetermineBrowsing
-      if ExecuteBashCommand(
-          Ops.add(@yast_bin_dir, "modify_cupsd_conf Browsing")
-        )
+      if ExecuteBashCommand(@yast_bin_dir + "modify_cupsd_conf Browsing")
         browsing = Builtins.tolower(Ops.get_string(@result, "stdout", "On"))
         if "off" == browsing || "no" == browsing
           @cupsd_conf_browsing_on = false
@@ -554,9 +548,7 @@ module Yast
     end
 
     def DetermineBrowseAllow
-      if ExecuteBashCommand(
-          Ops.add(@yast_bin_dir, "modify_cupsd_conf BrowseAllow")
-        )
+      if ExecuteBashCommand(@yast_bin_dir + "modify_cupsd_conf BrowseAllow")
         # but possible duplicate BrowseAllow values are not removed in the command output:
         @cupsd_conf_browse_allow = Builtins.toset(
           Builtins.splitstring(Ops.get_string(@result, "stdout", "all"), " ")
@@ -569,9 +561,7 @@ module Yast
     end
 
     def DetermineBrowsePoll
-      if ExecuteBashCommand(
-          Ops.add(@yast_bin_dir, "modify_cupsd_conf BrowsePoll")
-        )
+      if ExecuteBashCommand(@yast_bin_dir + "modify_cupsd_conf BrowsePoll")
         # but possible duplicate BrowsePoll values are not removed in the command output:
         @cupsd_conf_browse_poll = Builtins.toset(
           Builtins.splitstring(Ops.get_string(@result, "stdout", ""), " ")
@@ -604,9 +594,7 @@ module Yast
         dirty_clean_interval = 0
       end
       # Determine the DirtyCleanInterval value in /etc/cups/cupsd.conf:
-      if ExecuteBashCommand(
-          Ops.add(@yast_bin_dir, "modify_cupsd_conf DirtyCleanInterval")
-        )
+      if ExecuteBashCommand(@yast_bin_dir + "modify_cupsd_conf DirtyCleanInterval")
         # the latter would require 'import "Printer"' but Printer does already 'import "Printerlib"'
         # and a cyclic import drives the YaST machinery mad (it collapses with "too many open files"):
         dirty_clean_interval_string = Builtins.filterchars(
@@ -616,7 +604,7 @@ module Yast
         if "" != dirty_clean_interval_string &&
             nil != Builtins.tointeger(dirty_clean_interval_string)
           dirty_clean_interval = Builtins.tointeger(dirty_clean_interval_string)
-        end 
+        end
         # Use the above defined fallback value 30 or the CUPS 1.3.x value 0
         # when there is no DirtyCleanInterval entry (this applies also for CUPS 1.3.x)
         # or when the DirtyCleanInterval value cannot be converted to an integer.

--- a/src/modules/Printerlib.rb
+++ b/src/modules/Printerlib.rb
@@ -24,8 +24,7 @@
 # Summary:     Common functionality
 # Authors:     Michal Zugec <mzugec@suse.cz>
 #              Johannes Meixner <jsmeix@suse.de>
-#
-# $Id: Printerlib.ycp 27914 2006-02-13 14:32:08Z locilka $
+
 require "yast"
 
 module Yast


### PR DESCRIPTION
This is part of the YaST security audit by @jsegitz.

From the audit:

> yast2-printer/yast2-printer-4.0.2/src/modules/Printerlib.rb:96 
>
> ExecuteBashCommand should be reworked to receive an absolute path and arguments that then can be quoted/escaped

Unfortunately, this entire yast2-printer module is basically one large generator for the appropriate command lines. In many cases, those command lines contain 7-8 commands, often connected with a shell pipeline, or in other cases as individual commands separated by semicolons.

So simply changing this to accept one command with a  number of arguments that can then be properly shell-escaped is not an option.

Also, there is no test suite at all (the one that is present is merely a stub from the old YaST module template) and no unit tests. This can only be tested manually.

So, this PR will be for the maintainer of this module (@jsmeix) to merge and test. I am doing a best-effort approach here, but there is no way I can do any most basic testing.

_There be dragons._ And Ruby syntax errors. Not sure which is actually worse.


## Shell-Escaping Arguments

Whenever an argument to a command is not a fixed string, it might contain special characters; no matter if is user input or just the result of a non-trivial operation. So, such an argument needs to be shell-escaped to make sure the shell passes it as one argument and does not modify it.

If most cases, using single quotes (`'foo bar'`) is the appropriate thing; but this does not help if an argument may contain a single quote (`six o'clock`), in which case it gets weird (see explanations below).

So, in this pull request existing previous single quotes were removed and Ruby `shellescape()` used instead:

`"/usr/bin/foo -p '" + arg + "'"`
is now
`"/usr/bin/foo -p " + arg.shellescape`


## Shell-Escape vs. Regexp-Escape

There are many cases where shell pipelines are used to redirect the output of one command to the `grep` command. We have conflicting requirements here if the argument to `grep` also contains a variable that might contain special characters: Shell-escaping vs. Regexp-escaping.

Shell-escaping protects from the shell splitting up an argument into several arguments and from expanding shell wildcards (and some more).

Regexp-escaping protects from characters that are special to regular expressions being treated as such special characters; if we pass a string that was the result of user input or of another operation, we probably don't want this to happen. But at the same time, we still need to protect that argument from the shell.

In this PR there is **no** regexp-escaping. Doing that would get out of hand pretty quickly, and it is almost surely a pathological case.

Still, in most use cases the pragmatic approach is that we don't need to care. The only real world use case would be a period (`.`) which for a regexp means "any character"; this is very common in file names which are a likely thing to appear in such arguments, such as PPD files.

Still, it doesn't really matter, since `foo.ppd` _might_ also match `fooxppd` in such a regexp, but for one thing that output is almost guaranteed not to be present, and for another, such arguments are almost (?) always just a part of a regexp, typically enclosed in a leading and a trailing regexp part.

Please notice that in this PR it is common practice to single-quote that leading and that trailing part, but to shell-escape the variable part:

`" | grep '\s+'" + ppd.shellescape + "'\s[0-9]'"`

So this is a non-issue.


## Using Absolute Paths for all Commands

This YaST module contains tons of command lines that are being constructed from command line snippets. In many cases, they contain common Linux commands such as `cp`, `grep`, `tr`, `cut`, `sed`. Those common Linux commands were _not_ prefixed by an absolute path.

On the other hand, less common commands, typically those that are mostly relevant in the context of printing and administering printers, are always callled with their absolute path; it is always `/usr/bin/lpstat` or `/usr/bin/cups-config`, never just `lpstat` or `cups-config`. Other binaries that are specific to this yast-printer module or to YaST in general are always called with the YaST binary directory prefix.

Since the wrapper function `ExecuteBashCommand()` explicitly sets up a well-defined environment before calling a binary with a well-defined `$PATH`: 

https://github.com/yast/yast-printer/blob/master/src/modules/Printerlib.rb#L100

`export PATH='/sbin:/usr/sbin:/usr/bin:/bin'`

It does not contain the current directory, anything in the user's home directory or any other directory that is writable by anybody else than _root_.

So this is already as secure as it can possibly get. Adding explicit paths to each individual command would not add any security benefits.

---------------

## What Ruby shellescape() Does

https://ruby-doc.org/stdlib-2.5.0/libdoc/shellwords/rdoc/Shellwords.html#method-c-shellescape

> **shellescape(str)**
>
> Escapes a string so that it can be safely used in a Bourne shell command line. str can be a non-string object that responds to to_s.
>
> Note that a resulted string should be used unquoted and is not intended for use in double quotes nor in single quotes.

```Ruby
argv = "It's better to give than to receive".shellescape
argv #=> "It\\'s\\ better\\ to\\ give\\ than\\ to\\ receive"
```
_I.e. a part of a command line that was escaped by `shellescape()` may **NOT** be enclosed in single or double quotes._

Even if previously single quotes were used, It is better to remove those previous single quotes and use `shellescape()` instead because `shellescape()` also correctly takes care about strings that contain single quotes. 

The shell is quite weird with that; you cannot escape a single quote with a backslash, you have to terminate the old string, then escape the single quote with a backslash, then start a new string.

```
"It's painful"
```
Is correctly shell-escaped as

```
"It"\\'"s painful"
```

Yes, this **is** painful - and most unexpected by most developers. The shell is just weird in that regard.