### PR TITLE
Removed the libX11 dependency (bsc#1201641)

### DIFF
--- a/package/yast2-printer.changes
+++ b/package/yast2-printer.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Tue Jul 19 11:03:57 UTC 2022 - Ladislav Slezák <lslezak@suse.cz>
+
+- Removed the libX11 dependency (bsc#1201641)
+  (the old mechanism for that did not work anymore, use
+  %__requires_exclude_from)
+- 4.5.1
+
+-------------------------------------------------------------------
 Wed Apr 06 13:24:58 UTC 2022 - Ladislav Slezák <lslezak@suse.cz>
 
 - Bump version to 4.5.0 (bsc#1198109)

--- a/package/yast2-printer.spec
+++ b/package/yast2-printer.spec
@@ -1,7 +1,7 @@
 #
 # spec file for package yast2-printer
 #
-# Copyright (c) 2021 SUSE LLC
+# Copyright (c) 2022 SUSE LLC
 #
 # All modifications and additions to the file contributed by third parties
 # remain the property of their copyright owners, unless otherwise agreed
@@ -16,11 +16,8 @@
 #
 
 
-# Used to exclude libX11, libXau, libxcb, and libxcb-xlib from the requires list
-# which are pulled in by Autoreqprov because of the basicadd_displaytest tool:
-%define my_requires /tmp/my-requires
 Name:           yast2-printer
-Version:        4.5.0
+Version:        4.5.1
 Release:        0
 Summary:        YaST2 - Printer Configuration
 License:        GPL-2.0-only
@@ -42,6 +39,10 @@ Recommends:     samba-client
 Supplements:    autoyast(printer)
 Obsoletes:      yast2-printer-devel-doc
 
+# Exclude libX11 from the requires list which is pulled in by Autoreqprov
+# because of the basicadd_displaytest tool
+%global __requires_exclude_from basicadd_displaytest
+
 %description
 This package contains the YaST2 component for printer configuration.
 
@@ -53,13 +54,6 @@ This package contains the YaST2 component for printer configuration.
 
 %install
 %yast_install
-# Exclude libX11, libXau, libxcb, and libxcb-xlib from the requires list
-# which are pulled in by Autoreqprov because of the basicadd_displaytest tool:
-cat << EOF > %{my_requires}
-grep -v 'basicadd_displaytest' | %{__find_requires}
-EOF
-chmod 755 %{my_requires}
-%define __find_requires %{my_requires}
 %yast_metainfo
 
 %files


### PR DESCRIPTION
## Problem

- The package depends on the `libX11` library
- The spec file contained a mechanism to avoid this dependency, but it did not work anymore

## Solution

- Use the `%__requires_exclude_from` macro as documented in https://docs.fedoraproject.org/en-US/packaging-guidelines/AutoProvidesAndRequiresFiltering/#_preventing_filesdirectories_from_being_scanned_for_deps_pre_scan_filtering

## Testing

- Tested manually, the built package does not depend on `libX11` anymore

