### PR TITLE
Sle 12 sp5 bsc1084277

### DIFF
--- a/package/yast2-printer.changes
+++ b/package/yast2-printer.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Aug 10 08:14:04 UTC 2022 - Samuel Cabrero <scabrero@suse.de>
+
+- Try to connect with SMB3 protocol when testing SMB printers
+  (bsc#1084277)
+- 3.2.1
+
+-------------------------------------------------------------------
 Mon Jan 23 08:26:53 UTC 2017 - lslezak@suse.cz
 
 - Dropped yast2-core-devel build dependency, it is not needed

--- a/package/yast2-printer.spec
+++ b/package/yast2-printer.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-printer
-Version:        3.2.0
+Version:        3.2.1
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/tools/test_remote_smb
+++ b/tools/test_remote_smb
@@ -48,7 +48,7 @@ fi
 # Test whether the SMB share on the server accepts print jobs:
 echo -en "\nTesting share '$SHARE' on '$WORKGROUP/$HOST':\n"
 test -z "$PASSWORD" && PASSWORD="-N"
-if echo -en "\r" | $SMBCLIENT "//$HOST/$SHARE" "$PASSWORD" -c "print -" -U "$USER" -W "$WORKGROUP"
+if echo -en "\r" | $SMBCLIENT "//$HOST/$SHARE" "$PASSWORD" -c "print -" -U "$USER" -W "$WORKGROUP" -m SMB3
 then echo -en "\nShare '$SHARE' on '$WORKGROUP/$HOST' accepts print jobs\n"
      exit 0
 fi


### PR DESCRIPTION
## Problem

The test_remote_smb script fails when the print server only accepts SMB2+ protocol, because samba's default "client max protocol" is SMB1.

- https://bugzilla.suse.com/show_bug.cgi?id=1084277

## Solution

Add `-m SMB3` argument for smbclient to try to negotiate SMB3. 


## Testing

- *Tested manually*
